### PR TITLE
Fix health-check in backend Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -46,6 +46,6 @@ RUN chmod +x /app/entrypoint.sh
 EXPOSE 8000
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
-  CMD curl --fail http://localhost:8000/health || exit 1
+  CMD curl --fail http://localhost:8000/healthz || exit 1
 
 ENTRYPOINT ["/app/entrypoint.sh"]


### PR DESCRIPTION
Summary changes:

**Dockerfile**:

```Dockerfile
HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
  CMD uv run python -c "import requests; requests.get('http://localhost:8000/health')" || exit 1
```
Changed to:
```Dockerfile
HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
  CMD curl --fail http://localhost:8000/health || exit 1
```