### PR TITLE
feat: add auth to comments, likes, groups routers and resolve tag TODOs

### DIFF
--- a/backend/app/repositories/content.py
+++ b/backend/app/repositories/content.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.content import Content
+from app.repositories.base import Repository
+
+
+class ContentRepository(Repository):
+    def __init__(self, session: AsyncSession) -> None:
+        super().__init__(session)
+
+    async def get_author_id(self, content_id: UUID) -> UUID | None:
+        return await self.session.scalar(
+            select(Content.author_id).where(Content.id == content_id)
+        )

--- a/backend/app/routers/likes.py
+++ b/backend/app/routers/likes.py
@@ -1,14 +1,17 @@
+# ruff: noqa: B008
 from __future__ import annotations
 
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Request, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.auth import get_current_user
 from app.core.db import get_session
 from app.core.pagination import Limit, Offset, add_pagination_headers
 from app.schemas.like import LikeOut
+from app.schemas.user import Permissions, UserOut
 from app.services.likes import LikeService
 
 router = APIRouter(tags=["likes"])
@@ -22,6 +25,7 @@ async def list_content_likes(
     request: Request,
     response: Response,
     content_id: UUID,
+    current_user: UserOut = Depends(get_current_user),
     limit: Limit = 50,
     offset: Offset = 0,
 ):
@@ -45,16 +49,25 @@ async def list_content_likes(
 )
 async def like_content(
     session: SessionDep,
-    user_id: UUID,
     content_id: UUID,
+    current_user: UserOut = Depends(get_current_user),
 ):
     svc = LikeService(session)
-    comment = await svc.like_content(user_id=user_id, content_id=content_id)
-    return comment
+    return await svc.like_content(user_id=current_user.id, content_id=content_id)
 
 
-@router.delete("content/{content_id}/likes/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def unlike_content(session: SessionDep, user_id: UUID, content_id: UUID) -> None:
+@router.delete("/content/{content_id}/likes/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def unlike_content(
+    session: SessionDep,
+    user_id: UUID,
+    content_id: UUID,
+    current_user: UserOut = Depends(get_current_user),
+) -> None:
+    if user_id != current_user.id and current_user.permissions != Permissions.admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You can only remove your own likes.",
+        )
     svc = LikeService(session)
     await svc.delete(user_id=user_id, content_id=content_id)
     return None

--- a/backend/app/services/content.py
+++ b/backend/app/services/content.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.repositories.content import ContentRepository
+
+
+class ContentService:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+        self.repo = ContentRepository(session)
+
+    async def get_author_id(self, content_id: UUID) -> UUID:
+        author_id = await self.repo.get_author_id(content_id)
+        if author_id is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Content not found")
+        return author_id

--- a/backend/app/services/groups.py
+++ b/backend/app/services/groups.py
@@ -118,6 +118,14 @@ class GroupService:
             ) from None
         return created, GroupMembershipOut.model_validate(gs)
 
+    async def get_user_membership(
+        self, group_id: UUID, user_id: UUID
+    ) -> GroupMembershipOut | None:
+        gm = await self.repo.get_membership(group_id, user_id)
+        if not gm:
+            return None
+        return GroupMembershipOut.model_validate(gm)
+
     async def update_membership(
         self, group_id: UUID, user_id: UUID, data: GroupMembershipUpdate
     ) -> GroupMembershipOut:


### PR DESCRIPTION
- Add get_current_user to all unprotected endpoints in comments, likes, and groups
- Derive user identity from JWT instead of trusting client-supplied user_id
- Add check_group_access() to auth.py with GroupRole rank hierarchy, mirroring check_workspace_access
- Add get_user_membership() to GroupService and GroupRole-based checks per endpoint
- Fix missing /groups prefix on membership PATCH/DELETE routes
- Add ContentRepository and ContentService with get_author_id()
- Remove content_type query param from tag association endpoints (inferred via ContentService)
- Remove dead type-dispatch helper get_content_author_id from tags router