### PR TITLE
fix: auth token forwarding, CORS env var, and program create bug

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -15,6 +15,9 @@ TEST_DB_HOST = "localhost"
 TEST_DB_USER = "your_username"
 TEST_DB_PASSWORD = "your_password"
 
+# CORS configuration
+CORS_ORIGINS = '["http://localhost:3000", "https://slodi.is"]'
+
 # Auth0 configuration
 AUTH0_DOMAIN = "slodi.eu.auth0.com"
 AUTH0_AUDIENCE = "https://api.slodi.is"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.logging import configure_logging
+from app.settings import settings
 from app.routers import (
     comments_router,
     email_list_router,
@@ -27,11 +28,7 @@ def create_app() -> FastAPI:
     # Add CORS middleware
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=[
-            "http://localhost:3000",
-            "http://localhost:8000",
-            "https://slodi.is",
-        ],  # Frontend origin # TODO MAKE THIS AN ENVIROMENT VARIABLE
+        allow_origins=settings.cors_origins,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/backend/app/repositories/content.py
+++ b/backend/app/repositories/content.py
@@ -14,6 +14,4 @@ class ContentRepository(Repository):
         super().__init__(session)
 
     async def get_author_id(self, content_id: UUID) -> UUID | None:
-        return await self.session.scalar(
-            select(Content.author_id).where(Content.id == content_id)
-        )
+        return await self.session.scalar(select(Content.author_id).where(Content.id == content_id))

--- a/backend/app/repositories/workspaces.py
+++ b/backend/app/repositories/workspaces.py
@@ -65,13 +65,11 @@ class WorkspaceRepository(Repository):
         res = await self.session.execute(stmt)
         return res.rowcount or 0
 
-    async def get_user_membership(self, workspace_id: UUID, user_id: UUID) -> WorkspaceMembership | None:
-        stmt = (
-            select(WorkspaceMembership)
-            .where(
-                WorkspaceMembership.workspace_id == workspace_id,
-                WorkspaceMembership.user_id == user_id
-            )
+    async def get_user_membership(
+        self, workspace_id: UUID, user_id: UUID
+    ) -> WorkspaceMembership | None:
+        stmt = select(WorkspaceMembership).where(
+            WorkspaceMembership.workspace_id == workspace_id, WorkspaceMembership.user_id == user_id
         )
         res = await self.session.execute(stmt)
         return res.scalars().first()

--- a/backend/app/routers/programs.py
+++ b/backend/app/routers/programs.py
@@ -15,7 +15,6 @@ from app.schemas.program import ProgramCreate, ProgramOut, ProgramUpdate
 from app.schemas.user import UserOut
 from app.schemas.workspace import WorkspaceRole
 from app.services.programs import ProgramService
-from app.utils import get_current_datetime
 
 router = APIRouter(tags=["programs"])
 SessionDep = Annotated[AsyncSession, Depends(get_session)]
@@ -65,12 +64,7 @@ async def create_program_under_workspace(
     await check_workspace_access(
         workspace_id, current_user, session, minimum_role=WorkspaceRole.editor
     )
-    program_data = ProgramCreate(
-        **body.model_dump(),
-        author_id=current_user.id,
-        like_count=0,
-        created_at=get_current_datetime(),
-    )
+    program_data = body.model_copy(update={"author_id": current_user.id})
     svc = ProgramService(session)
     program = await svc.create_under_workspace(workspace_id, program_data)
     response.headers["Location"] = f"/programs/{program.id}"

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -84,5 +84,3 @@ class UserOut(UserBase):
     email: EmailConstrained
     auth0_id: Auth0Id
     name: NameStr
-
-

--- a/backend/app/services/groups.py
+++ b/backend/app/services/groups.py
@@ -118,9 +118,7 @@ class GroupService:
             ) from None
         return created, GroupMembershipOut.model_validate(gs)
 
-    async def get_user_membership(
-        self, group_id: UUID, user_id: UUID
-    ) -> GroupMembershipOut | None:
+    async def get_user_membership(self, group_id: UUID, user_id: UUID) -> GroupMembershipOut | None:
         gm = await self.repo.get_membership(group_id, user_id)
         if not gm:
             return None

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -31,6 +31,9 @@ class Settings(BaseSettings):
     auth0_audience: str = Field(..., alias="AUTH0_AUDIENCE")
     auth0_algorithms: list[str] = Field(["RS256"], alias="AUTH0_ALGORITHMS")
 
+    # CORS configuration
+    cors_origins: list[str] = Field(["http://localhost:3000"], alias="CORS_ORIGINS")
+
     def model_post_init(self, __context):
         # Production database URL
         self.db_url = f"postgresql+psycopg://{self.db_user}:{self.db_password}@{self.db_host}:{self.db_port}/{self.db_name}"

--- a/frontend/app/programs/favorites/page.tsx
+++ b/frontend/app/programs/favorites/page.tsx
@@ -3,6 +3,7 @@
 import React, { useMemo, useState, useEffect } from "react";
 import Link from "next/link";
 import { useFavorites } from "@/contexts/FavoritesContext";
+import { useAuth } from "@/contexts/AuthContext";
 import { fetchPrograms, type Program } from "@/services/programs.service";
 import ProgramCard from "@/app/programs/components/ProgramCard";
 import ProgramGrid from "../components/ProgramGrid";
@@ -14,6 +15,7 @@ const DEFAULT_WORKSPACE_ID = process.env.NEXT_PUBLIC_DEFAULT_WORKSPACE_ID || "";
 
 export default function FavoriteProgramsPage() {
   const { favorites, isLoading: favoritesLoading } = useFavorites();
+  const { getToken } = useAuth();
   const [sortBy, setSortBy] = useState<SortOption>('newest');
   const [programs, setPrograms] = useState<Program[]>([]);
   const [isLoadingPrograms, setIsLoadingPrograms] = useState(true);
@@ -23,7 +25,8 @@ export default function FavoriteProgramsPage() {
     async function loadPrograms() {
       try {
         setIsLoadingPrograms(true);
-        const data = await fetchPrograms(DEFAULT_WORKSPACE_ID);
+        const token = await getToken();
+        const data = await fetchPrograms(DEFAULT_WORKSPACE_ID, token ?? undefined);
         setPrograms(data);
       } catch (error) {
         console.error("Failed to fetch programs:", error);

--- a/frontend/hooks/usePrograms.ts
+++ b/frontend/hooks/usePrograms.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { fetchPrograms, extractTags, type Program } from "@/services/programs.service";
 import { handleApiError } from "@/lib/api-utils";
+import { useAuth } from "@/contexts/AuthContext";
 
 type UseProgramsResult = {
   programs: Program[] | null;
@@ -17,12 +18,14 @@ export default function usePrograms(workspaceId: string): UseProgramsResult {
   const [tags, setTags] = useState<string[] | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+  const { getToken } = useAuth();
 
   const loadPrograms = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const data = await fetchPrograms(workspaceId);
+      const token = await getToken();
+      const data = await fetchPrograms(workspaceId, token ?? undefined);
       setPrograms(data);
       setTags(extractTags(data));
     } catch (err) {
@@ -33,7 +36,7 @@ export default function usePrograms(workspaceId: string): UseProgramsResult {
     } finally {
       setLoading(false);
     }
-  }, [workspaceId]);
+  }, [workspaceId, getToken]);
 
   useEffect(() => {
     loadPrograms();

--- a/frontend/hooks/useTags.ts
+++ b/frontend/hooks/useTags.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { fetchTags, createTag as createTagApi, type Tag } from "@/services/tags.service";
 import { handleApiError } from "@/lib/api-utils";
+import { useAuth } from "@/contexts/AuthContext";
 
 type UseTagsResult = {
   tags: Tag[] | null;
@@ -17,12 +18,14 @@ export function useTags(query?: string): UseTagsResult {
   const [tags, setTags] = useState<Tag[] | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+  const { getToken } = useAuth();
 
   const loadTags = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const data = await fetchTags(query);
+      const token = await getToken();
+      const data = await fetchTags(query, token ?? undefined);
       setTags(data);
     } catch (err) {
       const errorMessage = handleApiError(err, "Failed to fetch tags");
@@ -31,7 +34,7 @@ export function useTags(query?: string): UseTagsResult {
     } finally {
       setLoading(false);
     }
-  }, [query]);
+  }, [query, getToken]);
 
   useEffect(() => {
     loadTags();

--- a/frontend/services/programs.service.ts
+++ b/frontend/services/programs.service.ts
@@ -66,10 +66,11 @@ export function canEditProgram(user: User | null, program: Program): boolean {
 /**
  * Fetch all programs for a workspace
  */
-export async function fetchPrograms(workspaceId: string): Promise<Program[]> {
+export async function fetchPrograms(workspaceId: string, token?: string): Promise<Program[]> {
   const url = buildApiUrl(`/workspaces/${workspaceId}/programs`);
   const data = await fetchAndCheck<ProgramsResponse>(url, {
     method: "GET",
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
     credentials: "include",
   });
 

--- a/frontend/services/tags.service.ts
+++ b/frontend/services/tags.service.ts
@@ -17,16 +17,18 @@ export type TagCreateInput = {
 /**
  * Fetch all tags
  * @param query Optional search query to filter tags by name
+ * @param token Bearer token for authentication
  */
-export async function fetchTags(query?: string): Promise<Tag[]> {
+export async function fetchTags(query?: string, token?: string): Promise<Tag[]> {
   const params = new URLSearchParams();
   if (query?.trim()) {
     params.append("q", query.trim());
   }
-  
+
   const url = buildApiUrl(`/tags${params.toString() ? `?${params.toString()}` : ''}`);
   return fetchAndCheck<Tag[]>(url, {
     method: "GET",
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
     credentials: "include",
   });
 }


### PR DESCRIPTION
- Add Authorization header to fetchPrograms and fetchTags so backend HTTPBearer auth doesn't return 403
- Thread token from useAuth into usePrograms, useTags, and favorites page
- Move CORS origins from hardcoded list to CORS_ORIGINS env var
- Fix ProgramCreate duplicate keyword arg error by using model_copy()
- Fix AUTH0_AUDIENCE typo in backend (https: -> https://)
- Add NEXT_PUBLIC_API_URL and AUTH0_AUDIENCE to frontend env config