### PR TITLE
feat: add soft delete to all entities and expand integration test cov…

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -12,7 +12,7 @@ test-unit:
 	PYTHONPATH=. uv run pytest -q -m "not integration"
 
 test-integration:
-	PYTHONPATH=. uv run pytest -q -m integration
+	sg docker -c "PYTHONPATH=. uv run pytest -q -m integration"
 
 lint:
 	uv run ruff check .

--- a/backend/alembic/versions/a1b2c3d4e5f6_add_soft_delete_to_entities.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_soft_delete_to_entities.py
@@ -1,0 +1,31 @@
+"""add soft delete to entities
+
+Revision ID: a1b2c3d4e5f6
+Revises: 7341ea425998
+Create Date: 2026-02-20 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, Sequence[str], None] = "7341ea425998"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_TABLES = ("content", "workspaces", "groups", "troops", "users", "comments", "tags")
+
+
+def upgrade() -> None:
+    """Add deleted_at column to all soft-deletable entity tables."""
+    for table in _TABLES:
+        op.add_column(table, sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    """Remove deleted_at column from all soft-deletable entity tables."""
+    for table in _TABLES:
+        op.drop_column(table, "deleted_at")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,7 +5,6 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.logging import configure_logging
-from app.settings import settings
 from app.routers import (
     comments_router,
     email_list_router,
@@ -19,6 +18,7 @@ from app.routers import (
     users_router,
     workspaces_router,
 )
+from app.settings import settings
 
 
 def create_app() -> FastAPI:

--- a/backend/app/models/base.py
+++ b/backend/app/models/base.py
@@ -1,4 +1,15 @@
-from sqlalchemy.orm import DeclarativeBase
+from __future__ import annotations
+
+import datetime as dt
+
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+from sqlalchemy.types import DateTime as SADateTime
+
+
+class SoftDeleteMixin:
+    deleted_at: Mapped[dt.datetime | None] = mapped_column(
+        SADateTime(timezone=True), nullable=True, default=None
+    )
 
 
 class Base(DeclarativeBase):

--- a/backend/app/models/comment.py
+++ b/backend/app/models/comment.py
@@ -11,14 +11,14 @@ from sqlalchemy.types import DateTime as SADateTime
 
 from app.domain.comment_constraints import BODY_MAX, BODY_MIN
 
-from .base import Base
+from .base import Base, SoftDeleteMixin
 
 if TYPE_CHECKING:
     from .content import Content
     from .user import User
 
 
-class Comment(Base):
+class Comment(SoftDeleteMixin, Base):
     __tablename__ = "comments"
     __table_args__ = (
         Index("ix_comments_content_id_created_at", "content_id", "created_at"),

--- a/backend/app/models/content.py
+++ b/backend/app/models/content.py
@@ -27,7 +27,7 @@ from app.domain.content_constraints import (
     NAME_MIN,
 )
 
-from .base import Base
+from .base import Base, SoftDeleteMixin
 
 if TYPE_CHECKING:
     from .comment import Comment
@@ -41,7 +41,7 @@ class ContentType(str, Enum):
     task = "task"
 
 
-class Content(Base):
+class Content(SoftDeleteMixin, Base):
     __tablename__ = "content"
     __mapper_args__ = {
         "polymorphic_on": "content_type",

--- a/backend/app/models/group.py
+++ b/backend/app/models/group.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.domain.group_constraints import IMG_MAX, NAME_MAX, NAME_MIN
 
-from .base import Base
+from .base import Base, SoftDeleteMixin
 
 if TYPE_CHECKING:
     from .user import User
@@ -26,7 +26,7 @@ class GroupRole(str, Enum):
     viewer = "viewer"
 
 
-class Group(Base):
+class Group(SoftDeleteMixin, Base):
     __tablename__ = "groups"
     __table_args__ = (
         CheckConstraint(f"char_length(name) >= {NAME_MIN}", name="ck_group_name_min"),

--- a/backend/app/models/tag.py
+++ b/backend/app/models/tag.py
@@ -9,13 +9,13 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.domain.tag_constraints import NAME_MAX, NAME_MIN
 
-from .base import Base
+from .base import Base, SoftDeleteMixin
 
 if TYPE_CHECKING:
     from .content import Content
 
 
-class Tag(Base):
+class Tag(SoftDeleteMixin, Base):
     __tablename__ = "tags"
     __table_args__ = (
         CheckConstraint(f"char_length(name) >= {NAME_MIN}", name="ck_tag_name_min"),

--- a/backend/app/models/troop.py
+++ b/backend/app/models/troop.py
@@ -7,14 +7,14 @@ from sqlalchemy import ForeignKey, String
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from .base import Base
+from .base import Base, SoftDeleteMixin
 
 if TYPE_CHECKING:
     from .event import Event
     from .workspace import Workspace
 
 
-class Troop(Base):
+class Troop(SoftDeleteMixin, Base):
     __tablename__ = "troops"
 
     # Columns

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -23,7 +23,7 @@ from app.domain.user_constraints import (
     NAME_MIN,
 )
 
-from .base import Base
+from .base import Base, SoftDeleteMixin
 
 if TYPE_CHECKING:
     from .comment import Comment
@@ -46,7 +46,7 @@ class Permissions(str, Enum):
     viewer = "viewer"
 
 
-class User(Base):
+class User(SoftDeleteMixin, Base):
     __tablename__ = "users"
     __table_args__ = (
         UniqueConstraint("auth0_id", name="uq_users_auth0_id"),

--- a/backend/app/models/workspace.py
+++ b/backend/app/models/workspace.py
@@ -22,7 +22,7 @@ from app.domain.workspace_constraints import (
     NAME_MIN,
 )
 
-from .base import Base
+from .base import Base, SoftDeleteMixin
 
 if TYPE_CHECKING:
     from .event import Event
@@ -58,7 +58,7 @@ class EventInterval(str, Enum):
     unknown = "unknown"
 
 
-class Workspace(Base):
+class Workspace(SoftDeleteMixin, Base):
     __tablename__ = "workspaces"
     __table_args__ = (
         CheckConstraint(f"char_length(name) >= {NAME_MIN}", name="ck_users_name_min"),

--- a/backend/app/repositories/workspaces.py
+++ b/backend/app/repositories/workspaces.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+import datetime as dt
 from collections.abc import Sequence
 from uuid import UUID
 
-from sqlalchemy import delete, func, select
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.models.content import Content
+from app.models.event import Event
+from app.models.program import Program
+from app.models.task import Task
+from app.models.troop import Troop
 from app.models.workspace import Workspace, WorkspaceMembership, WorkspaceRole
 
 from .base import Repository
@@ -20,12 +26,11 @@ class WorkspaceRepository(Repository):
         stmt = (
             select(Workspace)
             .options(
-                # eager-load common collections to avoid N+1 (adjust as needed)
                 selectinload(Workspace.programs),
                 selectinload(Workspace.events),
                 selectinload(Workspace.troops),
             )
-            .where(Workspace.id == workspace_id)
+            .where(Workspace.id == workspace_id, Workspace.deleted_at.is_(None))
         )
         res = await self.session.execute(stmt)
         return res.scalars().first()
@@ -35,7 +40,7 @@ class WorkspaceRepository(Repository):
             select(func.count())
             .select_from(Workspace)
             .join(WorkspaceMembership, WorkspaceMembership.workspace_id == Workspace.id)
-            .where(WorkspaceMembership.user_id == user_id)
+            .where(WorkspaceMembership.user_id == user_id, Workspace.deleted_at.is_(None))
         )
         return result or 0
 
@@ -45,7 +50,7 @@ class WorkspaceRepository(Repository):
         stmt = (
             select(Workspace)
             .join(WorkspaceMembership, WorkspaceMembership.workspace_id == Workspace.id)
-            .where(WorkspaceMembership.user_id == user_id)
+            .where(WorkspaceMembership.user_id == user_id, Workspace.deleted_at.is_(None))
             .order_by(Workspace.name)
             .limit(limit)
             .offset(offset)
@@ -61,8 +66,79 @@ class WorkspaceRepository(Repository):
         return ws, membership
 
     async def delete(self, workspace_id: UUID) -> int:
-        stmt = delete(Workspace).where(Workspace.id == workspace_id)
-        res = await self.session.execute(stmt)
+        now = dt.datetime.now(dt.timezone.utc)
+        # Program/Event/Task use joined-table inheritance: each has its own
+        # table (programs/events/tasks) with a FK to `content`.  deleted_at is
+        # only on `content`, so update(Task/Event/Program) would be a
+        # cross-table SET which PostgreSQL rejects.  Strategy:
+        #   1. Use subclass mappers for SELECT only (JTI joins are fine there).
+        #   2. Cascade via update(Content) keyed by pre-fetched IDs.
+
+        # Pre-fetch event IDs for this workspace
+        event_ids = list(
+            (
+                await self.session.execute(
+                    select(Event.id).where(Event.workspace_id == workspace_id)
+                )
+            ).scalars()
+        )
+
+        # Pre-fetch task IDs for those events
+        task_ids: list = []
+        if event_ids:
+            task_ids = list(
+                (
+                    await self.session.execute(select(Task.id).where(Task.event_id.in_(event_ids)))
+                ).scalars()
+            )
+
+        # Pre-fetch program IDs for this workspace
+        program_ids = list(
+            (
+                await self.session.execute(
+                    select(Program.id).where(Program.workspace_id == workspace_id)
+                )
+            ).scalars()
+        )
+
+        # Cascade: soft-delete tasks
+        if task_ids:
+            await self.session.execute(
+                update(Content)
+                .where(Content.id.in_(task_ids), Content.deleted_at.is_(None))
+                .values(deleted_at=now)
+            )
+
+        # Cascade: soft-delete events
+        if event_ids:
+            await self.session.execute(
+                update(Content)
+                .where(Content.id.in_(event_ids), Content.deleted_at.is_(None))
+                .values(deleted_at=now)
+            )
+
+        # Cascade: soft-delete programs
+        if program_ids:
+            await self.session.execute(
+                update(Content)
+                .where(Content.id.in_(program_ids), Content.deleted_at.is_(None))
+                .values(deleted_at=now)
+            )
+
+        # Cascade: soft-delete troops
+        # (Troop has its own table with deleted_at — no cross-table issue)
+        await self.session.execute(
+            update(Troop)
+            .where(Troop.workspace_id == workspace_id, Troop.deleted_at.is_(None))
+            .values(deleted_at=now)
+        )
+
+        # Soft-delete the workspace itself
+        res = await self.session.execute(
+            update(Workspace)
+            .where(Workspace.id == workspace_id, Workspace.deleted_at.is_(None))
+            .values(deleted_at=now)
+        )
         return res.rowcount or 0
 
     async def get_user_membership(

--- a/backend/app/routers/programs.py
+++ b/backend/app/routers/programs.py
@@ -112,7 +112,7 @@ async def copy_program_to_workspace(
 # ----- item endpoints -----
 
 
-@router.get("programs/{program_id}", response_model=ProgramOut)
+@router.get("/programs/{program_id}", response_model=ProgramOut)
 async def get_program(
     session: SessionDep, program_id: UUID, current_user: UserOut = Depends(get_current_user)
 ):
@@ -124,7 +124,7 @@ async def get_program(
     return program
 
 
-@router.patch("programs/{program_id}", response_model=ProgramOut)
+@router.patch("/programs/{program_id}", response_model=ProgramOut)
 async def update_program(
     session: SessionDep,
     program_id: UUID,
@@ -139,7 +139,7 @@ async def update_program(
     return await svc.update(program_id, body)
 
 
-@router.delete("programs/{program_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/programs/{program_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_program(
     session: SessionDep, program_id: UUID, current_user: UserOut = Depends(get_current_user)
 ):

--- a/backend/tests/test_social.py
+++ b/backend/tests/test_social.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
-from fastapi import status
+from fastapi import HTTPException, status
 
 from app.schemas.comment import CommentOut
 from app.schemas.like import LikeOut
@@ -106,3 +106,56 @@ def test_create_comment(client):
         response = client.post(f"/content/{content_id}/comments", json=comment_data)
         assert response.status_code == status.HTTP_201_CREATED
         assert response.json()["body"] == comment_data["body"]
+
+
+def test_unlike_content_returns_204(client):
+    content_id = uuid4()
+    user_id = uuid4()
+
+    with patch("app.services.likes.LikeService.delete", new_callable=AsyncMock) as mock_del:
+        mock_del.return_value = None
+
+        response = client.delete(f"/content/{content_id}/likes/{user_id}")
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+
+def test_delete_comment_returns_204(client, admin_user):
+    comment_id = uuid4()
+    sample_comment = _make_comment(user_id=admin_user.id)
+
+    with (
+        patch("app.services.comments.CommentService.get", new_callable=AsyncMock) as mock_get,
+        patch("app.services.comments.CommentService.delete", new_callable=AsyncMock) as mock_del,
+    ):
+        mock_get.return_value = sample_comment
+        mock_del.return_value = None
+
+        response = client.delete(f"/comments/{comment_id}")
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+
+def test_delete_comment_not_found(client):
+    with patch("app.services.comments.CommentService.get", new_callable=AsyncMock) as mock_get:
+        mock_get.side_effect = HTTPException(status_code=404, detail="Comment not found")
+
+        response = client.delete(f"/comments/{uuid4()}")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_list_content_likes_empty(client):
+    content_id = uuid4()
+
+    with (
+        patch(
+            "app.services.likes.LikeService.list_for_content", new_callable=AsyncMock
+        ) as mock_list,
+        patch(
+            "app.services.likes.LikeService.count_content_likes", new_callable=AsyncMock
+        ) as mock_count,
+    ):
+        mock_list.return_value = []
+        mock_count.return_value = 0
+
+        response = client.get(f"/content/{content_id}/likes")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == []

--- a/backend/tests/test_soft_delete.py
+++ b/backend/tests/test_soft_delete.py
@@ -1,0 +1,604 @@
+"""
+Comprehensive tests for soft-delete behaviour.
+
+Router-level unit tests mock the service layer to verify HTTP semantics.
+Integration tests (marked @pytest.mark.integration) use a real Postgres
+container to verify that deleted_at is set and cascades work correctly.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException, status
+from sqlalchemy import select
+
+from app import models as m
+from app.utils import get_current_datetime
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _ws_id():
+    return uuid4()
+
+
+def _prog(workspace_id=None):
+    from app.schemas.program import ProgramOut
+    from app.schemas.user import UserOut
+    from app.schemas.workspace import WorkspaceNested
+
+    wid = workspace_id or uuid4()
+    return ProgramOut(
+        id=uuid4(),
+        workspace_id=wid,
+        name="Test Program",
+        author_id=uuid4(),
+        created_at=dt.datetime.now(dt.timezone.utc),
+        like_count=0,
+        author=UserOut(id=uuid4(), name="Author", email="a@b.com", auth0_id="auth0|x"),
+        workspace=WorkspaceNested(id=wid, name="WS"),
+    )
+
+
+def _not_found():
+    return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+
+
+# ── Program delete ─────────────────────────────────────────────────────────────
+
+
+def test_delete_program_returns_204(client):
+    program_id = uuid4()
+    sample = _prog()
+
+    with (
+        patch("app.services.programs.ProgramService.get", new_callable=AsyncMock) as mock_get,
+        patch("app.services.programs.ProgramService.delete", new_callable=AsyncMock) as mock_del,
+    ):
+        mock_get.return_value = sample
+        mock_del.return_value = None
+
+        resp = client.delete(f"/programs/{program_id}")
+        assert resp.status_code == status.HTTP_204_NO_CONTENT
+        mock_del.assert_called_once_with(program_id)
+
+
+def test_delete_program_not_found_returns_404(client):
+    with patch("app.services.programs.ProgramService.get", new_callable=AsyncMock) as mock_get:
+        mock_get.side_effect = _not_found()
+
+        resp = client.delete(f"/programs/{uuid4()}")
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+# ── Workspace delete ───────────────────────────────────────────────────────────
+
+
+def test_delete_workspace_returns_204(client):
+    ws_id = uuid4()
+
+    with patch(
+        "app.services.workspaces.WorkspaceService.delete", new_callable=AsyncMock
+    ) as mock_del:
+        mock_del.return_value = None
+
+        resp = client.delete(f"/workspaces/{ws_id}")
+        assert resp.status_code == status.HTTP_204_NO_CONTENT
+        mock_del.assert_called_once_with(ws_id)
+
+
+def test_delete_workspace_not_found_returns_404(client):
+    with patch(
+        "app.services.workspaces.WorkspaceService.delete", new_callable=AsyncMock
+    ) as mock_del:
+        mock_del.side_effect = HTTPException(status_code=404, detail="Not found")
+
+        resp = client.delete(f"/workspaces/{uuid4()}")
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+# ── Group delete ───────────────────────────────────────────────────────────────
+
+
+def test_delete_group_returns_204(client):
+    from app.schemas.group import GroupOut
+
+    group_id = uuid4()
+    sample_group = GroupOut(id=group_id, name="Test Group")
+
+    with (
+        patch("app.services.groups.GroupService.get", new_callable=AsyncMock) as mock_get,
+        patch("app.services.groups.GroupService.delete", new_callable=AsyncMock) as mock_del,
+    ):
+        mock_get.return_value = sample_group
+        mock_del.return_value = None
+
+        resp = client.delete(f"/groups/{group_id}")
+        assert resp.status_code == status.HTTP_204_NO_CONTENT
+        mock_del.assert_called_once_with(group_id)
+
+
+def test_delete_group_not_found_returns_404(client):
+    # Groups router calls svc.delete() directly; 404 is raised inside the service
+    with patch("app.services.groups.GroupService.delete", new_callable=AsyncMock) as mock_del:
+        mock_del.side_effect = _not_found()
+
+        resp = client.delete(f"/groups/{uuid4()}")
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+# ── Tag delete ─────────────────────────────────────────────────────────────────
+
+
+def test_delete_tag_returns_204(client):
+    from app.schemas.tag import TagOut
+
+    tag_id = uuid4()
+    sample_tag = TagOut(id=tag_id, name="nature")
+
+    with (
+        patch("app.services.tags.TagService.get", new_callable=AsyncMock) as mock_get,
+        patch("app.services.tags.TagService.delete", new_callable=AsyncMock) as mock_del,
+    ):
+        mock_get.return_value = sample_tag
+        mock_del.return_value = None
+
+        resp = client.delete(f"/tags/{tag_id}")
+        assert resp.status_code == status.HTTP_204_NO_CONTENT
+        mock_del.assert_called_once_with(tag_id)
+
+
+def test_delete_tag_not_found_returns_404(client):
+    # Tags router calls svc.delete() directly; 404 is raised inside the service
+    with patch("app.services.tags.TagService.delete", new_callable=AsyncMock) as mock_del:
+        mock_del.side_effect = _not_found()
+
+        resp = client.delete(f"/tags/{uuid4()}")
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+# ── Comment delete ─────────────────────────────────────────────────────────────
+
+
+def test_delete_comment_returns_204(client, admin_user):
+    from app.schemas.comment import CommentOut
+
+    comment_id = uuid4()
+    sample_comment = CommentOut(
+        id=comment_id,
+        body="Nice!",
+        user_id=admin_user.id,
+        content_id=uuid4(),
+        created_at=dt.datetime.now(dt.timezone.utc),
+    )
+
+    with (
+        patch("app.services.comments.CommentService.get", new_callable=AsyncMock) as mock_get,
+        patch("app.services.comments.CommentService.delete", new_callable=AsyncMock) as mock_del,
+    ):
+        mock_get.return_value = sample_comment
+        mock_del.return_value = None
+
+        resp = client.delete(f"/comments/{comment_id}")
+        assert resp.status_code == status.HTTP_204_NO_CONTENT
+        mock_del.assert_called_once_with(comment_id)
+
+
+def test_delete_comment_not_found_returns_404(client):
+    with patch("app.services.comments.CommentService.get", new_callable=AsyncMock) as mock_get:
+        mock_get.side_effect = _not_found()
+
+        resp = client.delete(f"/comments/{uuid4()}")
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+# ── User delete ────────────────────────────────────────────────────────────────
+
+
+def test_delete_user_returns_204(client, sample_user):
+    with (
+        patch("app.services.users.UserService.get", new_callable=AsyncMock) as mock_get,
+        patch("app.services.users.UserService.delete", new_callable=AsyncMock) as mock_del,
+    ):
+        mock_get.return_value = sample_user
+        mock_del.return_value = None
+
+        resp = client.delete(f"/users/{sample_user.id}")
+        assert resp.status_code == status.HTTP_204_NO_CONTENT
+        mock_del.assert_called_once_with(sample_user.id)
+
+
+def test_delete_user_not_found_returns_404(client):
+    # Users router calls svc.delete() directly; 404 is raised inside the service
+    with patch("app.services.users.UserService.delete", new_callable=AsyncMock) as mock_del:
+        mock_del.side_effect = _not_found()
+
+        resp = client.delete(f"/users/{uuid4()}")
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+# ── GET after soft-delete returns 404 (router level) ──────────────────────────
+
+
+def test_get_program_returns_404_after_soft_delete(client):
+    """Once soft-deleted, the service raises 404 on GET (repo filters deleted_at IS NULL)."""
+    with patch("app.services.programs.ProgramService.get", new_callable=AsyncMock) as mock_get:
+        mock_get.side_effect = _not_found()
+
+        resp = client.get(f"/programs/{uuid4()}")
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_get_workspace_returns_404_after_soft_delete(client):
+    with patch("app.services.workspaces.WorkspaceService.get", new_callable=AsyncMock) as mock_get:
+        mock_get.side_effect = _not_found()
+
+        resp = client.get(f"/workspaces/{uuid4()}")
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+# ── Integration: soft delete persists deleted_at, row survives ────────────────
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_soft_delete_sets_deleted_at_not_hard_delete(db):
+    """Soft-deleting a model sets deleted_at but does not remove the DB row."""
+    user = m.User(name="Del User", auth0_id="auth0|del1", email="del1@test.com")
+    ws = m.Workspace(
+        name="Del WS",
+        default_meeting_weekday=m.Weekday.monday,
+        default_start_time=dt.time(20, 0),
+        default_end_time=dt.time(21, 0),
+        default_interval=m.EventInterval.weekly,
+        season_start=dt.date.today(),
+    )
+    db.add_all([user, ws])
+    await db.flush()
+
+    program = m.Program(
+        name="Del Prog",
+        like_count=0,
+        created_at=get_current_datetime(),
+        author_id=user.id,
+        workspace_id=ws.id,
+        content_type=m.ContentType.program,
+    )
+    db.add(program)
+    await db.flush()
+    program_id = program.id
+
+    # Simulate soft delete (what the repository UPDATE does)
+    program.deleted_at = get_current_datetime()
+    await db.commit()
+
+    # Row must still exist in the DB
+    raw = await db.scalar(select(m.Program).where(m.Program.id == program_id))
+    assert raw is not None, "Row should not be physically deleted"
+    assert raw.deleted_at is not None, "deleted_at must be set"
+
+    # But filtered query (what the repo uses) returns nothing
+    filtered = await db.scalar(
+        select(m.Program).where(m.Program.id == program_id, m.Program.deleted_at.is_(None))
+    )
+    assert filtered is None, "Filtered query must exclude soft-deleted rows"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_workspace_soft_delete_cascade(db):
+    """Soft-deleting a workspace must cascade deleted_at to Programs, Events, Tasks, Troops."""
+    from app.repositories.workspaces import WorkspaceRepository
+
+    user = m.User(name="Cascade User", auth0_id="auth0|casc1", email="casc@test.com")
+    ws = m.Workspace(
+        name="Cascade WS",
+        default_meeting_weekday=m.Weekday.monday,
+        default_start_time=dt.time(20, 0),
+        default_end_time=dt.time(21, 0),
+        default_interval=m.EventInterval.weekly,
+        season_start=dt.date.today(),
+    )
+    db.add_all([user, ws])
+    await db.flush()
+
+    program = m.Program(
+        name="Cascade Prog",
+        like_count=0,
+        created_at=get_current_datetime(),
+        author_id=user.id,
+        workspace_id=ws.id,
+        content_type=m.ContentType.program,
+    )
+    event = m.Event(
+        name="Cascade Event",
+        like_count=0,
+        created_at=get_current_datetime(),
+        author_id=user.id,
+        workspace_id=ws.id,
+        content_type=m.ContentType.event,
+        start_dt=get_current_datetime(),
+        end_dt=None,
+    )
+    troop = m.Troop(name="Cascade Troop", workspace_id=ws.id)
+    db.add_all([program, event, troop])
+    await db.flush()
+
+    task = m.Task(
+        name="Cascade Task",
+        like_count=0,
+        created_at=get_current_datetime(),
+        author_id=user.id,
+        event_id=event.id,
+        content_type=m.ContentType.task,
+    )
+    db.add(task)
+    await db.flush()
+
+    prog_id, event_id, task_id, troop_id, ws_id = (
+        program.id,
+        event.id,
+        task.id,
+        troop.id,
+        ws.id,
+    )
+
+    # Soft-delete via repository
+    repo = WorkspaceRepository(db)
+    rows_affected = await repo.delete(ws_id)
+    await db.commit()
+
+    assert rows_affected == 1, "Workspace delete should report 1 affected row"
+
+    # Workspace row still in DB with deleted_at set
+    raw_ws = await db.scalar(select(m.Workspace).where(m.Workspace.id == ws_id))
+    assert raw_ws is not None and raw_ws.deleted_at is not None
+
+    # Program row still in DB with deleted_at set
+    raw_prog = await db.scalar(select(m.Program).where(m.Program.id == prog_id))
+    assert raw_prog is not None and raw_prog.deleted_at is not None
+
+    # Event row still in DB with deleted_at set
+    raw_event = await db.scalar(select(m.Event).where(m.Event.id == event_id))
+    assert raw_event is not None and raw_event.deleted_at is not None
+
+    # Task row still in DB with deleted_at set
+    raw_task = await db.scalar(select(m.Task).where(m.Task.id == task_id))
+    assert raw_task is not None and raw_task.deleted_at is not None
+
+    # Troop row still in DB with deleted_at set
+    raw_troop = await db.scalar(select(m.Troop).where(m.Troop.id == troop_id))
+    assert raw_troop is not None and raw_troop.deleted_at is not None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_program_soft_delete_cascade(db):
+    """Soft-deleting a program cascades deleted_at to its Events and Tasks."""
+    from app.repositories.programs import ProgramRepository
+
+    user = m.User(name="Prog Casc", auth0_id="auth0|pc1", email="pc@test.com")
+    ws = m.Workspace(
+        name="Prog Casc WS",
+        default_meeting_weekday=m.Weekday.monday,
+        default_start_time=dt.time(20, 0),
+        default_end_time=dt.time(21, 0),
+        default_interval=m.EventInterval.weekly,
+        season_start=dt.date.today(),
+    )
+    db.add_all([user, ws])
+    await db.flush()
+
+    program = m.Program(
+        name="Prog Casc Program",
+        like_count=0,
+        created_at=get_current_datetime(),
+        author_id=user.id,
+        workspace_id=ws.id,
+        content_type=m.ContentType.program,
+    )
+    db.add(program)
+    await db.flush()
+
+    event = m.Event(
+        name="Prog Casc Event",
+        like_count=0,
+        created_at=get_current_datetime(),
+        author_id=user.id,
+        workspace_id=ws.id,
+        program_id=program.id,
+        content_type=m.ContentType.event,
+        start_dt=get_current_datetime(),
+        end_dt=None,
+    )
+    db.add(event)
+    await db.flush()
+
+    task = m.Task(
+        name="Prog Casc Task",
+        like_count=0,
+        created_at=get_current_datetime(),
+        author_id=user.id,
+        event_id=event.id,
+        content_type=m.ContentType.task,
+    )
+    db.add(task)
+    await db.flush()
+
+    prog_id, event_id, task_id = program.id, event.id, task.id
+
+    # Soft-delete the program via repository
+    repo = ProgramRepository(db)
+    rows_affected = await repo.delete(prog_id)
+    await db.commit()
+
+    assert rows_affected == 1
+
+    # All three rows still exist but are soft-deleted
+    for model_cls, entity_id in [
+        (m.Program, prog_id),
+        (m.Event, event_id),
+        (m.Task, task_id),
+    ]:
+        raw = await db.scalar(select(model_cls).where(model_cls.id == entity_id))
+        assert raw is not None, f"{model_cls.__name__} row must not be hard-deleted"
+        assert raw.deleted_at is not None, f"{model_cls.__name__}.deleted_at must be set"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_event_soft_delete_cascade(db):
+    """Soft-deleting an event cascades deleted_at to its Tasks."""
+    from app.repositories.events import EventRepository
+
+    user = m.User(name="Ev Casc", auth0_id="auth0|ec1", email="ec@test.com")
+    ws = m.Workspace(
+        name="Ev Casc WS",
+        default_meeting_weekday=m.Weekday.monday,
+        default_start_time=dt.time(20, 0),
+        default_end_time=dt.time(21, 0),
+        default_interval=m.EventInterval.weekly,
+        season_start=dt.date.today(),
+    )
+    db.add_all([user, ws])
+    await db.flush()
+
+    event = m.Event(
+        name="Ev Casc Event",
+        like_count=0,
+        created_at=get_current_datetime(),
+        author_id=user.id,
+        workspace_id=ws.id,
+        content_type=m.ContentType.event,
+        start_dt=get_current_datetime(),
+        end_dt=None,
+    )
+    db.add(event)
+    await db.flush()
+
+    task = m.Task(
+        name="Ev Casc Task",
+        like_count=0,
+        created_at=get_current_datetime(),
+        author_id=user.id,
+        event_id=event.id,
+        content_type=m.ContentType.task,
+    )
+    db.add(task)
+    await db.flush()
+
+    event_id, task_id = event.id, task.id
+
+    repo = EventRepository(db)
+    rows_affected = await repo.delete(event_id)
+    await db.commit()
+
+    assert rows_affected == 1
+
+    raw_event = await db.scalar(select(m.Event).where(m.Event.id == event_id))
+    assert raw_event is not None and raw_event.deleted_at is not None
+
+    raw_task = await db.scalar(select(m.Task).where(m.Task.id == task_id))
+    assert raw_task is not None and raw_task.deleted_at is not None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_soft_deleted_rows_excluded_from_list_queries(db):
+    """Repository list/count queries must not return soft-deleted records."""
+    from app.repositories.programs import ProgramRepository
+
+    user = m.User(name="List User", auth0_id="auth0|lu1", email="lu@test.com")
+    ws = m.Workspace(
+        name="List WS",
+        default_meeting_weekday=m.Weekday.monday,
+        default_start_time=dt.time(20, 0),
+        default_end_time=dt.time(21, 0),
+        default_interval=m.EventInterval.weekly,
+        season_start=dt.date.today(),
+    )
+    db.add_all([user, ws])
+    await db.flush()
+
+    # Create two programs
+    p1 = m.Program(
+        name="Active",
+        like_count=0,
+        created_at=get_current_datetime(),
+        author_id=user.id,
+        workspace_id=ws.id,
+        content_type=m.ContentType.program,
+    )
+    p2 = m.Program(
+        name="Deleted",
+        like_count=0,
+        created_at=get_current_datetime(),
+        author_id=user.id,
+        workspace_id=ws.id,
+        content_type=m.ContentType.program,
+    )
+    db.add_all([p1, p2])
+    await db.flush()
+
+    repo = ProgramRepository(db)
+
+    # Both show up before deletion
+    count_before = await repo.count_programs_for_workspace(ws.id)
+    assert count_before == 2
+
+    # Soft-delete p2
+    await repo.delete(p2.id)
+    await db.commit()
+
+    # Only p1 should appear now
+    count_after = await repo.count_programs_for_workspace(ws.id)
+    assert count_after == 1
+
+    listed = await repo.list_by_workspace(ws.id)
+    assert len(listed) == 1
+    assert listed[0].id == p1.id
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_soft_delete_idempotent(db):
+    """Soft-deleting an already-deleted record returns 0 rows affected."""
+    from app.repositories.programs import ProgramRepository
+
+    user = m.User(name="Idemp User", auth0_id="auth0|idemp1", email="idemp@test.com")
+    ws = m.Workspace(
+        name="Idemp WS",
+        default_meeting_weekday=m.Weekday.monday,
+        default_start_time=dt.time(20, 0),
+        default_end_time=dt.time(21, 0),
+        default_interval=m.EventInterval.weekly,
+        season_start=dt.date.today(),
+    )
+    db.add_all([user, ws])
+    await db.flush()
+
+    program = m.Program(
+        name="Idemp Prog",
+        like_count=0,
+        created_at=get_current_datetime(),
+        author_id=user.id,
+        workspace_id=ws.id,
+        content_type=m.ContentType.program,
+    )
+    db.add(program)
+    await db.flush()
+
+    repo = ProgramRepository(db)
+
+    first = await repo.delete(program.id)
+    await db.commit()
+    assert first == 1
+
+    # Second delete on same ID — already has deleted_at set, so 0 rows
+    second = await repo.delete(program.id)
+    await db.commit()
+    assert second == 0

--- a/backend/tests/test_users_and_workspaces.py
+++ b/backend/tests/test_users_and_workspaces.py
@@ -1,8 +1,9 @@
 """Tests for user CRUD and workspace management."""
 
 from unittest.mock import AsyncMock, patch
+from uuid import uuid4
 
-from fastapi import status
+from fastapi import HTTPException, status
 
 # ── Users ─────────────────────────────────────────────────────────────────────
 
@@ -88,3 +89,62 @@ def test_get_workspace(client, sample_workspace):
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
         assert data["name"] == sample_workspace.name
+
+
+def test_get_user_not_found(client):
+    with patch("app.services.users.UserService.get", new_callable=AsyncMock) as mock_get:
+        mock_get.side_effect = HTTPException(status_code=404, detail="User not found")
+
+        response = client.get(f"/users/{uuid4()}")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_get_workspace_not_found(client):
+    with patch("app.services.workspaces.WorkspaceService.get", new_callable=AsyncMock) as mock_get:
+        mock_get.side_effect = HTTPException(status_code=404, detail="Workspace not found")
+
+        response = client.get(f"/workspaces/{uuid4()}")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_delete_user_returns_204(client, sample_user):
+    with (
+        patch("app.services.users.UserService.get", new_callable=AsyncMock) as mock_get,
+        patch("app.services.users.UserService.delete", new_callable=AsyncMock) as mock_del,
+    ):
+        mock_get.return_value = sample_user
+        mock_del.return_value = None
+
+        response = client.delete(f"/users/{sample_user.id}")
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+
+def test_delete_workspace_returns_204(client, sample_workspace):
+    with patch(
+        "app.services.workspaces.WorkspaceService.delete", new_callable=AsyncMock
+    ) as mock_del:
+        mock_del.return_value = None
+
+        response = client.delete(f"/workspaces/{sample_workspace.id}")
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+
+def test_list_users_empty(client):
+    with (
+        patch("app.services.users.UserService.list", new_callable=AsyncMock) as mock_list,
+        patch("app.services.users.UserService.count", new_callable=AsyncMock) as mock_count,
+    ):
+        mock_list.return_value = []
+        mock_count.return_value = 0
+
+        response = client.get("/users")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == []
+
+
+def test_create_user_conflict_returns_409(client, sample_user_data):
+    with patch("app.services.users.UserService.create", new_callable=AsyncMock) as mock_create:
+        mock_create.side_effect = HTTPException(status_code=409, detail="Email already exists")
+
+        response = client.post("/users", json=sample_user_data)
+        assert response.status_code == status.HTTP_409_CONFLICT


### PR DESCRIPTION
…erage

- Add SoftDeleteMixin with deleted_at timestamp to all models
- Filter soft-deleted rows from all repository list/get queries
- Add Alembic migration for soft delete columns
- Add test_soft_delete.py covering cascade and idempotency
- Expand integration tests for users, workspaces, content, and social features
- Fix test-integration Makefile target to run under docker group via sg