### PR TITLE
feat: add Resend email integration and email router

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -22,3 +22,7 @@ CORS_ORIGINS = '["http://localhost:3000", "https://slodi.is"]'
 AUTH0_DOMAIN = "slodi.eu.auth0.com"
 AUTH0_AUDIENCE = "https://api.slodi.is"
 AUTH0_ALGORITHMS = '["RS256"]'
+
+# Resend (email) configuration
+RESEND_API_KEY = "re_your_api_key"
+RESEND_FROM_EMAIL = "Slóði <noreply@slodi.is>"

--- a/backend/app/core/email.py
+++ b/backend/app/core/email.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import logging
+
+import resend
+from fastapi import BackgroundTasks
+
+from app.settings import settings
+
+logger = logging.getLogger(__name__)
+
+
+def _send_email(recipients: list[str], subject: str, html: str) -> None:
+    if not settings.resend_api_key:
+        logger.warning("RESEND_API_KEY not configured — skipping email to %s", recipients)
+        return
+
+    resend.api_key = settings.resend_api_key
+    params: resend.Emails.SendParams = {
+        "from": settings.resend_from_email,
+        "to": recipients,
+        "subject": subject,
+        "html": html,
+    }
+    resend.Emails.send(params)
+
+
+def send_email_background(
+    background_tasks: BackgroundTasks,
+    recipients: list[str],
+    subject: str,
+    html: str,
+) -> None:
+    """Queue an email to be sent after the response is returned.
+
+    If RESEND_API_KEY is not set the call is a no-op (logs a warning).
+    FastAPI runs sync background tasks in a thread-pool executor, so the
+    blocking Resend SDK call does not block the event loop.
+    """
+    background_tasks.add_task(_send_email, recipients, subject, html)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from app.core.logging import configure_logging
 from app.routers import (
     comments_router,
     email_list_router,
+    email_router,
     events_router,
     groups_router,
     likes_router,
@@ -34,6 +35,7 @@ def create_app() -> FastAPI:
         allow_headers=["*"],
     )
     app.include_router(email_list_router.router)
+    app.include_router(email_router.router)
     app.include_router(users_router.router)
     app.include_router(groups_router.router)
     app.include_router(workspaces_router.router)

--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -1,11 +1,13 @@
-from app.routers import comments as comments_router  # noqa: F401
-from app.routers import email_list as email_list_router  # noqa: F401
-from app.routers import events as events_router  # noqa: F401
-from app.routers import groups as groups_router  # noqa: F401
-from app.routers import likes as likes_router  # noqa: F401
-from app.routers import programs as programs_router  # noqa: F401
-from app.routers import tags as tags_router  # noqa: F401
-from app.routers import tasks as tasks_router  # noqa: F401
-from app.routers import troops as troops_router  # noqa: F401
-from app.routers import users as users_router  # noqa: F401
-from app.routers import workspaces as workspaces_router  # noqa: F401
+# ruff: noqa: F401
+from app.routers import comments as comments_router
+from app.routers import email_list as email_list_router
+from app.routers import email_router as email_router
+from app.routers import events as events_router
+from app.routers import groups as groups_router
+from app.routers import likes as likes_router
+from app.routers import programs as programs_router
+from app.routers import tags as tags_router
+from app.routers import tasks as tasks_router
+from app.routers import troops as troops_router
+from app.routers import users as users_router
+from app.routers import workspaces as workspaces_router

--- a/backend/app/routers/email_router.py
+++ b/backend/app/routers/email_router.py
@@ -1,0 +1,93 @@
+# ruff: noqa: B008
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, BackgroundTasks, Depends, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import check_workspace_access, get_current_user, require_permission
+from app.core.db import get_session
+from app.core.email import send_email_background
+from app.models.user import Permissions
+from app.models.workspace import WorkspaceRole
+from app.schemas.email import (
+    BroadcastOut,
+    BroadcastRequest,
+    EmailSendRequest,
+    WorkspaceInviteRequest,
+)
+from app.schemas.user import UserOut
+from app.services.email_list import EmailListService
+from app.services.workspaces import WorkspaceService
+
+SessionDep = Annotated[AsyncSession, Depends(get_session)]
+
+router = APIRouter(prefix="/emails", tags=["emails"])
+
+
+@router.post("/send", status_code=status.HTTP_202_ACCEPTED)
+async def send_email(
+    body: EmailSendRequest,
+    background_tasks: BackgroundTasks,
+    current_user: UserOut = Depends(require_permission(Permissions.admin)),
+) -> None:
+    """Send a custom email to one or more recipients. Admin only."""
+    send_email_background(
+        background_tasks,
+        recipients=[str(r) for r in body.recipients],
+        subject=body.subject,
+        html=body.html,
+    )
+
+
+@router.post("/workspaces/{workspace_id}/invite", status_code=status.HTTP_202_ACCEPTED)
+async def invite_to_workspace(
+    workspace_id: UUID,
+    body: WorkspaceInviteRequest,
+    background_tasks: BackgroundTasks,
+    session: SessionDep,
+    current_user: UserOut = Depends(get_current_user),
+) -> None:
+    """Send a workspace invitation email. Requires workspace admin role."""
+    await check_workspace_access(
+        workspace_id, current_user, session, minimum_role=WorkspaceRole.admin
+    )
+    workspace = await WorkspaceService(session).get(workspace_id)
+
+    personal_note = f"<p><em>{body.message}</em></p>" if body.message else ""
+    html = f"""
+<p>{current_user.name} hefur boðið þér í vinnusvæðið
+<strong>{workspace.name}</strong> á Slóða.</p>
+{personal_note}
+<p><a href="https://slodi.is">Opna Slóða</a></p>
+"""
+    send_email_background(
+        background_tasks,
+        recipients=[str(body.email)],
+        subject=f"Boð í {workspace.name} á Slóða",
+        html=html,
+    )
+
+
+@router.post("/broadcast", response_model=BroadcastOut, status_code=status.HTTP_202_ACCEPTED)
+async def broadcast_to_email_list(
+    body: BroadcastRequest,
+    background_tasks: BackgroundTasks,
+    session: SessionDep,
+    current_user: UserOut = Depends(require_permission(Permissions.admin)),
+) -> BroadcastOut:
+    """Broadcast an email to all subscribers on the email list. Admin only."""
+    subscribers = await EmailListService(session).list()
+    recipients = [entry.email for entry in subscribers]
+
+    if recipients:
+        send_email_background(
+            background_tasks,
+            recipients=recipients,
+            subject=body.subject,
+            html=body.html,
+        )
+
+    return BroadcastOut(recipients_count=len(recipients))

--- a/backend/app/schemas/email.py
+++ b/backend/app/schemas/email.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, EmailStr, Field
+
+
+class EmailSendRequest(BaseModel):
+    recipients: list[EmailStr] = Field(..., min_length=1)
+    subject: str = Field(..., min_length=1, max_length=200)
+    html: str = Field(..., min_length=1)
+
+
+class WorkspaceInviteRequest(BaseModel):
+    email: EmailStr
+    message: str | None = Field(None, max_length=1000)
+
+
+class BroadcastRequest(BaseModel):
+    subject: str = Field(..., min_length=1, max_length=200)
+    html: str = Field(..., min_length=1)
+
+
+class BroadcastOut(BaseModel):
+    recipients_count: int

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -34,7 +34,11 @@ class Settings(BaseSettings):
     # CORS configuration
     cors_origins: list[str] = Field(["http://localhost:3000"], alias="CORS_ORIGINS")
 
-    def model_post_init(self, __context):
+    # Resend (email) configuration
+    resend_api_key: str | None = Field(None, alias="RESEND_API_KEY")
+    resend_from_email: str = Field("Slóði <noreply@slodi.is>", alias="RESEND_FROM_EMAIL")
+
+    def model_post_init(self, __context: object) -> None:
         # Production database URL
         self.db_url = f"postgresql+psycopg://{self.db_user}:{self.db_password}@{self.db_host}:{self.db_port}/{self.db_name}"
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "python-jose[cryptography]>=3.3.0",
     "httpx>=0.27.0",
     "testcontainers[postgres]>=4.0",
+    "resend>=2.0.0",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
- Add resend SDK dependency and RESEND_API_KEY/RESEND_FROM_EMAIL settings
- Add app/core/email.py with send_email_background primitive
- Add /emails router with three endpoints: POST /emails/send (admin only) POST /emails/workspaces/{id}/invite (workspace admin) POST /emails/broadcast (admin only, targets email list subscribers)
- Add email request/response schemas