### PR TITLE
feat: replace stored like_count with computed SQL subqueries for cont…

### DIFF
--- a/backend/alembic/versions/c1d2e3f4a5b6_drop_like_count_from_content.py
+++ b/backend/alembic/versions/c1d2e3f4a5b6_drop_like_count_from_content.py
@@ -1,0 +1,30 @@
+"""drop like_count from content
+
+Revision ID: c1d2e3f4a5b6
+Revises: a1b2c3d4e5f6
+Create Date: 2026-02-21 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c1d2e3f4a5b6"
+down_revision: Union[str, None] = "a1b2c3d4e5f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("ck_content_like_nonneg", "content", type_="check")
+    op.drop_column("content", "like_count")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "content",
+        sa.Column("like_count", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.create_check_constraint("ck_content_like_nonneg", "content", "like_count >= 0")

--- a/backend/app/models/content.py
+++ b/backend/app/models/content.py
@@ -49,7 +49,6 @@ class Content(SoftDeleteMixin, Base):
         "with_polymorphic": "*",
     }
     __table_args__ = (
-        CheckConstraint("like_count >= 0", name="ck_content_like_nonneg"),
         CheckConstraint("count >= 0", name="ck_content_count_nonneg"),
         CheckConstraint("price >= 0", name="ck_content_price_nonneg"),
         CheckConstraint(f"char_length(name) >= {NAME_MIN}", name="ck_content_name_min"),
@@ -79,10 +78,6 @@ class Content(SoftDeleteMixin, Base):
     count: Mapped[int | None] = mapped_column(Integer, nullable=True)
     price: Mapped[int | None] = mapped_column(Integer, nullable=True)
     prep_time: Mapped[str | None] = mapped_column(String(DURATION_MAX), nullable=True)
-    like_count: Mapped[int] = mapped_column(
-        Integer,
-        nullable=False,
-    )
     created_at: Mapped[dt.datetime] = mapped_column(
         SADateTime(timezone=True),
         nullable=False,
@@ -107,8 +102,3 @@ class Content(SoftDeleteMixin, Base):
     def tags(self) -> list[Tag]:
         """Return list of Tag objects from content_tags relationship"""
         return [ct.tag for ct in self.content_tags]
-
-    @property
-    def comment_count(self) -> int:
-        """Return count of comments for this content"""
-        return len(self.comments) if self.comments else 0

--- a/backend/app/repositories/content.py
+++ b/backend/app/repositories/content.py
@@ -1,12 +1,60 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Any
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import false, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.comment import Comment
 from app.models.content import Content
+from app.models.like import UserLikedContent
 from app.repositories.base import Repository
+
+
+@dataclass
+class ContentStats:
+    like_count: int
+    comment_count: int
+    liked_by_me: bool
+
+
+def like_count_subq() -> Any:
+    """Correlated subquery: COUNT of likes for the current Content row."""
+    return (
+        select(func.count())
+        .select_from(UserLikedContent)
+        .where(UserLikedContent.content_id == Content.id)
+        .correlate(Content)
+        .scalar_subquery()
+    )
+
+
+def comment_count_subq() -> Any:
+    """Correlated subquery: COUNT of non-deleted comments for the current Content row."""
+    return (
+        select(func.count())
+        .select_from(Comment)
+        .where(Comment.content_id == Content.id, Comment.deleted_at.is_(None))
+        .correlate(Content)
+        .scalar_subquery()
+    )
+
+
+def liked_by_me_subq(current_user_id: UUID | None) -> Any:
+    """Correlated EXISTS subquery: True if current_user has liked the row."""
+    if current_user_id is None:
+        return false()
+    return (
+        select(UserLikedContent.user_id)
+        .where(
+            UserLikedContent.content_id == Content.id,
+            UserLikedContent.user_id == current_user_id,
+        )
+        .correlate(Content)
+        .exists()
+    )
 
 
 class ContentRepository(Repository):

--- a/backend/app/repositories/tasks.py
+++ b/backend/app/repositories/tasks.py
@@ -1,38 +1,61 @@
 from __future__ import annotations
 
 import datetime as dt
-from collections.abc import Sequence
 from uuid import UUID
 
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.models.content import Content
 from app.models.task import Task
 from app.repositories.base import Repository
+from app.repositories.content import (
+    ContentStats,
+    comment_count_subq,
+    like_count_subq,
+    liked_by_me_subq,
+)
 
 
 class TaskRepository(Repository):
     def __init__(self, session: AsyncSession) -> None:
         super().__init__(session)
 
-    async def get(self, task_id: UUID) -> Task | None:
+    async def get(
+        self, task_id: UUID, current_user_id: UUID | None = None
+    ) -> tuple[Task, ContentStats] | None:
         stmt = (
-            select(Task)
+            select(Task, like_count_subq(), comment_count_subq(), liked_by_me_subq(current_user_id))
             .options(
+                selectinload(Task.author),
                 selectinload(Task.event),
+                selectinload(Task.content_tags),
             )
             .where(Task.id == task_id, Task.deleted_at.is_(None))
         )
-        res = await self.session.execute(stmt)
-        return res.scalars().first()
+        row = (await self.session.execute(stmt)).first()
+        if row is None:
+            return None
+        task, lc, cc, lm = row
+        return task, ContentStats(like_count=int(lc), comment_count=int(cc), liked_by_me=bool(lm))
 
-    async def get_in_event(self, task_id: UUID, event_id: UUID) -> Task | None:
-        stmt = select(Task).where(
-            Task.id == task_id, Task.event_id == event_id, Task.deleted_at.is_(None)
+    async def get_in_event(
+        self, task_id: UUID, event_id: UUID, current_user_id: UUID | None = None
+    ) -> tuple[Task, ContentStats] | None:
+        stmt = (
+            select(Task, like_count_subq(), comment_count_subq(), liked_by_me_subq(current_user_id))
+            .options(
+                selectinload(Task.author),
+                selectinload(Task.content_tags),
+            )
+            .where(Task.id == task_id, Task.event_id == event_id, Task.deleted_at.is_(None))
         )
-        res = await self.session.execute(stmt)
-        return res.scalars().first()
+        row = (await self.session.execute(stmt)).first()
+        if row is None:
+            return None
+        task, lc, cc, lm = row
+        return task, ContentStats(like_count=int(lc), comment_count=int(cc), liked_by_me=bool(lm))
 
     async def count_tasks_for_event(self, event_id: UUID) -> int:
         result = await self.session.scalar(
@@ -45,18 +68,23 @@ class TaskRepository(Repository):
     async def list_for_event(
         self,
         event_id: UUID,
+        current_user_id: UUID | None = None,
         *,
         limit: int = 50,
         offset: int = 0,
-    ) -> Sequence[Task]:
+    ) -> list[tuple[Task, ContentStats]]:
         stmt = (
-            select(Task)
+            select(Task, like_count_subq(), comment_count_subq(), liked_by_me_subq(current_user_id))
             .where(Task.event_id == event_id, Task.deleted_at.is_(None))
             .order_by(Task.name)
             .limit(limit)
             .offset(offset)
         )
-        return await self.scalars(stmt)
+        rows = (await self.session.execute(stmt)).all()
+        return [
+            (task, ContentStats(like_count=int(lc), comment_count=int(cc), liked_by_me=bool(lm)))
+            for task, lc, cc, lm in rows
+        ]
 
     async def create(self, task: Task) -> Task:
         await self.add(task)
@@ -65,6 +93,8 @@ class TaskRepository(Repository):
     async def delete(self, task_id: UUID) -> int:
         now = dt.datetime.now(dt.timezone.utc)
         res = await self.session.execute(
-            update(Task).where(Task.id == task_id, Task.deleted_at.is_(None)).values(deleted_at=now)
+            update(Content)
+            .where(Content.id == task_id, Content.deleted_at.is_(None))
+            .values(deleted_at=now)
         )
         return res.rowcount or 0

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -44,7 +44,12 @@ async def list_workspace_events(
     svc = EventService(session)
     total = await svc.count_events_for_workspace(workspace_id, date_from=date_from, date_to=date_to)
     items = await svc.list_for_workspace(
-        workspace_id, date_from=date_from, date_to=date_to, limit=limit, offset=offset
+        workspace_id,
+        current_user.id,
+        date_from=date_from,
+        date_to=date_to,
+        limit=limit,
+        offset=offset,
     )
     add_pagination_headers(
         response=response,
@@ -82,6 +87,7 @@ async def list_program_events(
     items = await svc.list_for_program(
         workspace_id,
         program_id,
+        current_user.id,
         date_from=date_from,
         date_to=date_to,
         limit=limit,
@@ -135,7 +141,7 @@ async def create_program_event(
     from app.services.programs import ProgramService  # Avoid circular import
 
     prg_svc = ProgramService(session)
-    program = await prg_svc.get(program_id)
+    program = await prg_svc.get(program_id, current_user.id)
     await check_workspace_access(
         program.workspace_id, current_user, session, minimum_role=WorkspaceRole.editor
     )
@@ -153,7 +159,7 @@ async def get_event(
     session: SessionDep, event_id: UUID, current_user: UserOut = Depends(get_current_user)
 ) -> EventOut:
     svc = EventService(session)
-    event = await svc.get(event_id)
+    event = await svc.get(event_id, current_user.id)
     await check_workspace_access(
         event.workspace_id, current_user, session, minimum_role=WorkspaceRole.viewer
     )
@@ -168,11 +174,11 @@ async def update_event(
     current_user: UserOut = Depends(get_current_user),
 ) -> EventOut:
     svc = EventService(session)
-    event = await svc.get(event_id)
+    event = await svc.get(event_id, current_user.id)
     await check_workspace_access(
         event.workspace_id, current_user, session, minimum_role=WorkspaceRole.editor
     )
-    return await svc.update(event_id, body)
+    return await svc.update(event_id, body, current_user.id)
 
 
 @router.delete("/events/{event_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -180,7 +186,7 @@ async def delete_event(
     session: SessionDep, event_id: UUID, current_user: UserOut = Depends(get_current_user)
 ) -> None:
     svc = EventService(session)
-    event = await svc.get(event_id)
+    event = await svc.get(event_id, current_user.id)
     await check_workspace_access(
         event.workspace_id, current_user, session, minimum_role=WorkspaceRole.admin
     )

--- a/backend/app/routers/programs.py
+++ b/backend/app/routers/programs.py
@@ -37,7 +37,7 @@ async def list_workspace_programs(
         workspace_id, current_user, session, minimum_role=WorkspaceRole.viewer
     )
     total = await svc.count_programs_for_workspace(workspace_id)
-    items = await svc.list_for_workspace(workspace_id, limit=limit, offset=offset)
+    items = await svc.list_for_workspace(workspace_id, current_user.id, limit=limit, offset=offset)
     add_pagination_headers(
         response=response,
         request=request,
@@ -99,7 +99,6 @@ async def copy_program_to_workspace(
         location=original_program.location,
         count=original_program.count,
         price=original_program.price,
-        like_count=0,
         author_id=user_id,
         content_type=ContentType.program,
         image=original_program.image,
@@ -117,7 +116,7 @@ async def get_program(
     session: SessionDep, program_id: UUID, current_user: UserOut = Depends(get_current_user)
 ) -> ProgramOut:
     svc = ProgramService(session)
-    program = await svc.get(program_id)
+    program = await svc.get(program_id, current_user.id)
     await check_workspace_access(
         program.workspace_id, current_user, session, minimum_role=WorkspaceRole.viewer
     )
@@ -132,11 +131,11 @@ async def update_program(
     current_user: UserOut = Depends(get_current_user),
 ) -> ProgramOut:
     svc = ProgramService(session)
-    program = await svc.get(program_id)
+    program = await svc.get(program_id, current_user.id)
     await check_workspace_access(
         program.workspace_id, current_user, session, minimum_role=WorkspaceRole.admin
     )
-    return await svc.update(program_id, body)
+    return await svc.update(program_id, body, current_user.id)
 
 
 @router.delete("/programs/{program_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -36,12 +36,12 @@ async def list_event_tasks(
 ) -> list[TaskOut]:
     svc = TaskService(session)
     event_svc = EventService(session)
-    event = await event_svc.get(event_id)
+    event = await event_svc.get(event_id, current_user.id)
     await check_workspace_access(
         event.workspace_id, current_user, session, minimum_role=WorkspaceRole.viewer
     )
     total = await svc.count_tasks_for_event(event_id)
-    items = await svc.list_for_event(event_id, limit=limit, offset=offset)
+    items = await svc.list_for_event(event_id, current_user.id, limit=limit, offset=offset)
     add_pagination_headers(
         response=response,
         request=request,
@@ -67,7 +67,7 @@ async def create_event_task(
     assert body.content_type == ContentType.task, "Content type must be 'task'"
     svc = TaskService(session)
     event_svc = EventService(session)
-    event = await event_svc.get(event_id)
+    event = await event_svc.get(event_id, current_user.id)
     await check_workspace_access(
         event.workspace_id, current_user, session, minimum_role=WorkspaceRole.editor
     )
@@ -85,8 +85,8 @@ async def get_task(
 ) -> TaskOut:
     svc = TaskService(session)
     event_svc = EventService(session)
-    task = await svc.get(task_id)
-    event = await event_svc.get(task.event_id)
+    task = await svc.get(task_id, current_user.id)
+    event = await event_svc.get(task.event_id, current_user.id)
     await check_workspace_access(
         event.workspace_id, current_user, session, minimum_role=WorkspaceRole.editor
     )
@@ -102,12 +102,12 @@ async def update_task(
 ) -> TaskOut:
     svc = TaskService(session)
     event_svc = EventService(session)
-    task = await svc.get(task_id)
-    event = await event_svc.get(task.event_id)
+    task = await svc.get(task_id, current_user.id)
+    event = await event_svc.get(task.event_id, current_user.id)
     await check_workspace_access(
         event.workspace_id, current_user, session, minimum_role=WorkspaceRole.editor
     )
-    return await svc.update(task_id, body)
+    return await svc.update(task_id, body, current_user.id)
 
 
 @router.delete("/tasks/{task_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -116,8 +116,8 @@ async def delete_task(
 ) -> None:
     svc = TaskService(session)
     event_svc = EventService(session)
-    task = await svc.get(task_id)
-    event = await event_svc.get(task.event_id)
+    task = await svc.get(task_id, current_user.id)
+    event = await event_svc.get(task.event_id, current_user.id)
     await check_workspace_access(
         event.workspace_id, current_user, session, minimum_role=WorkspaceRole.editor
     )

--- a/backend/app/services/tasks.py
+++ b/backend/app/services/tasks.py
@@ -19,40 +19,64 @@ class TaskService:
         return await self.repo.count_tasks_for_event(event_id)
 
     async def list_for_event(
-        self, event_id: UUID, *, limit: int = 50, offset: int = 0
+        self,
+        event_id: UUID,
+        current_user_id: UUID | None = None,
+        *,
+        limit: int = 50,
+        offset: int = 0,
     ) -> list[TaskOut]:
-        rows = await self.repo.list_for_event(event_id, limit=limit, offset=offset)
-        return [TaskOut.model_validate(r) for r in rows]
+        rows = await self.repo.list_for_event(event_id, current_user_id, limit=limit, offset=offset)
+        return [TaskOut.from_row(task, stats) for task, stats in rows]
 
     async def create_under_event(self, event_id: UUID, data: TaskCreate) -> TaskOut:
         task = Task(event_id=event_id, **data.model_dump())
         await self.repo.create(task)
         await self.session.commit()
-        await self.session.refresh(task)
-        return TaskOut.model_validate(task)
+        fetched = await self.repo.get(task.id)
+        if not fetched:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to retrieve created task",
+            )
+        t, stats = fetched
+        return TaskOut.from_row(t, stats)
 
-    async def get(self, task_id: UUID) -> TaskOut:
+    async def get(self, task_id: UUID, current_user_id: UUID | None = None) -> TaskOut:
+        row = await self.repo.get(task_id, current_user_id)
+        if not row:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found")
+        task, stats = row
+        return TaskOut.from_row(task, stats)
+
+    async def get_in_event(
+        self, task_id: UUID, event_id: UUID, current_user_id: UUID | None = None
+    ) -> TaskOut:
+        row = await self.repo.get_in_event(task_id, event_id, current_user_id)
+        if not row:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found")
+        task, stats = row
+        return TaskOut.from_row(task, stats)
+
+    async def update(
+        self, task_id: UUID, data: TaskUpdate, current_user_id: UUID | None = None
+    ) -> TaskOut:
         row = await self.repo.get(task_id)
         if not row:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found")
-        return TaskOut.model_validate(row)
-
-    async def get_in_event(self, task_id: UUID, event_id: UUID) -> TaskOut:
-        row = await self.repo.get_in_event(task_id, event_id)
-        if not row:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found")
-        return TaskOut.model_validate(row)
-
-    async def update(self, task_id: UUID, data: TaskUpdate) -> TaskOut:
-        row = await self.repo.get(task_id)
-        if not row:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found")
+        task, _ = row
         patch = data.model_dump(exclude_unset=True)
         for k, v in patch.items():
-            setattr(row, k, v)
+            setattr(task, k, v)
         await self.session.commit()
-        await self.session.refresh(row)
-        return TaskOut.model_validate(row)
+        updated = await self.repo.get(task_id, current_user_id)
+        if not updated:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to retrieve updated task",
+            )
+        t, stats = updated
+        return TaskOut.from_row(t, stats)
 
     async def delete(self, task_id: UUID) -> None:
         deleted = await self.repo.delete(task_id)

--- a/backend/tests/test_models_integration.py
+++ b/backend/tests/test_models_integration.py
@@ -41,7 +41,6 @@ async def test_user_workspace_program_event_task_flow(db):
     program = m.Program(
         name="Fall Skills",
         description=None,
-        like_count=0,
         created_at=get_current_datetime(),
         author_id=user.id,
         workspace_id=workspace.id,
@@ -58,7 +57,6 @@ async def test_user_workspace_program_event_task_flow(db):
     event = m.Event(
         name="Campout",
         description="Overnight",
-        like_count=0,
         created_at=get_current_datetime(),
         author_id=user.id,
         workspace_id=workspace.id,
@@ -74,7 +72,6 @@ async def test_user_workspace_program_event_task_flow(db):
     task = m.Task(
         name="Setup tents",
         description=None,
-        like_count=0,
         created_at=get_current_datetime(),
         author_id=user.id,
         event_id=event.id,
@@ -118,7 +115,6 @@ async def test_tags_and_comments_and_cascade(db):
     p = m.Program(
         name="Prog",
         description=None,
-        like_count=0,
         created_at=get_current_datetime(),
         author_id=u.id,
         workspace_id=ws.id,
@@ -194,7 +190,6 @@ async def test_group_membership_and_troops(db):
     p = m.Program(
         name="Prog2",
         description=None,
-        like_count=0,
         created_at=get_current_datetime(),
         author_id=u.id,
         workspace_id=ws.id,
@@ -203,7 +198,6 @@ async def test_group_membership_and_troops(db):
     e = m.Event(
         name="Hike",
         description=None,
-        like_count=0,
         created_at=get_current_datetime(),
         author_id=u.id,
         workspace_id=ws.id,

--- a/backend/tests/test_schemas.py
+++ b/backend/tests/test_schemas.py
@@ -33,24 +33,12 @@ def test_workspace_defaults_in_schema():
     assert isinstance(w.season_start, dt.date)
 
 
-def test_content_like_count_non_negative():
-    with pytest.raises(ValidationError):
-        s.ContentCreate(
-            name="N",
-            description=None,
-            like_count=-1,
-            created_at=get_current_datetime(),
-            author_id=uuid4(),
-        )
-
-
 def test_event_time_is_tz_aware():
     # naive -> invalid
     with pytest.raises(ValidationError):
         s.EventCreate(
             name="Camp",
             description=None,
-            like_count=0,
             created_at=get_current_datetime(),
             author_id=uuid4(),
             content_type=m.ContentType.event,
@@ -65,7 +53,6 @@ def test_task_participants_rules():
             content_type=m.ContentType.task,
             name="Knot tying",
             description=None,
-            like_count=0,
             created_at=get_current_datetime(),
             author_id=uuid4(),
             participant_min=5,
@@ -78,7 +65,6 @@ def test_task_participants_rules():
             content_type=m.ContentType.task,
             name="Game",
             description=None,
-            like_count=0,
             created_at=get_current_datetime(),
             author_id=uuid4(),
             participant_min=0,

--- a/backend/tests/test_soft_delete.py
+++ b/backend/tests/test_soft_delete.py
@@ -38,7 +38,6 @@ def _prog(workspace_id=None):
         name="Test Program",
         author_id=uuid4(),
         created_at=dt.datetime.now(dt.timezone.utc),
-        like_count=0,
         author=UserOut(id=uuid4(), name="Author", email="a@b.com", auth0_id="auth0|x"),
         workspace=WorkspaceNested(id=wid, name="WS"),
     )
@@ -262,7 +261,6 @@ async def test_soft_delete_sets_deleted_at_not_hard_delete(db):
 
     program = m.Program(
         name="Del Prog",
-        like_count=0,
         created_at=get_current_datetime(),
         author_id=user.id,
         workspace_id=ws.id,
@@ -308,7 +306,6 @@ async def test_workspace_soft_delete_cascade(db):
 
     program = m.Program(
         name="Cascade Prog",
-        like_count=0,
         created_at=get_current_datetime(),
         author_id=user.id,
         workspace_id=ws.id,
@@ -316,7 +313,6 @@ async def test_workspace_soft_delete_cascade(db):
     )
     event = m.Event(
         name="Cascade Event",
-        like_count=0,
         created_at=get_current_datetime(),
         author_id=user.id,
         workspace_id=ws.id,
@@ -330,7 +326,6 @@ async def test_workspace_soft_delete_cascade(db):
 
     task = m.Task(
         name="Cascade Task",
-        like_count=0,
         created_at=get_current_datetime(),
         author_id=user.id,
         event_id=event.id,
@@ -395,7 +390,6 @@ async def test_program_soft_delete_cascade(db):
 
     program = m.Program(
         name="Prog Casc Program",
-        like_count=0,
         created_at=get_current_datetime(),
         author_id=user.id,
         workspace_id=ws.id,
@@ -406,7 +400,6 @@ async def test_program_soft_delete_cascade(db):
 
     event = m.Event(
         name="Prog Casc Event",
-        like_count=0,
         created_at=get_current_datetime(),
         author_id=user.id,
         workspace_id=ws.id,
@@ -420,7 +413,6 @@ async def test_program_soft_delete_cascade(db):
 
     task = m.Task(
         name="Prog Casc Task",
-        like_count=0,
         created_at=get_current_datetime(),
         author_id=user.id,
         event_id=event.id,
@@ -469,7 +461,6 @@ async def test_event_soft_delete_cascade(db):
 
     event = m.Event(
         name="Ev Casc Event",
-        like_count=0,
         created_at=get_current_datetime(),
         author_id=user.id,
         workspace_id=ws.id,
@@ -482,7 +473,6 @@ async def test_event_soft_delete_cascade(db):
 
     task = m.Task(
         name="Ev Casc Task",
-        like_count=0,
         created_at=get_current_datetime(),
         author_id=user.id,
         event_id=event.id,
@@ -527,7 +517,6 @@ async def test_soft_deleted_rows_excluded_from_list_queries(db):
     # Create two programs
     p1 = m.Program(
         name="Active",
-        like_count=0,
         created_at=get_current_datetime(),
         author_id=user.id,
         workspace_id=ws.id,
@@ -535,7 +524,6 @@ async def test_soft_deleted_rows_excluded_from_list_queries(db):
     )
     p2 = m.Program(
         name="Deleted",
-        like_count=0,
         created_at=get_current_datetime(),
         author_id=user.id,
         workspace_id=ws.id,
@@ -560,7 +548,8 @@ async def test_soft_deleted_rows_excluded_from_list_queries(db):
 
     listed = await repo.list_by_workspace(ws.id)
     assert len(listed) == 1
-    assert listed[0].id == p1.id
+    prog, _ = listed[0]
+    assert prog.id == p1.id
 
 
 @pytest.mark.integration
@@ -583,7 +572,6 @@ async def test_soft_delete_idempotent(db):
 
     program = m.Program(
         name="Idemp Prog",
-        like_count=0,
         created_at=get_current_datetime(),
         author_id=user.id,
         workspace_id=ws.id,


### PR DESCRIPTION
…ent stats

Remove the denormalized like_count column from the content table and replace it — along with comment_count and liked_by_me — with correlated SQL subqueries computed in a single query per endpoint. Introduces a ContentStats dataclass bundling the three computed fields, returned as tuple[Entity, ContentStats] from all program/event/task repositories, and ContentOut.from_row(obj, stats) for clean schema construction.

- Drop like_count column and ck_content_like_nonneg constraint (Alembic migration)
- Add like_count_subq(), comment_count_subq(), liked_by_me_subq() helpers in ContentRepository
- Remove comment_count property from Content model (was len(self.comments))
- All three repositories select four columns and unpack inline (no helper function)
- Services and routers pass current_user_id through for personalised liked_by_me
- Update tests to remove like_count fixtures and fix tuple unpacking