### PR TITLE
feat: refactor auth module and harden workspace access controls

### DIFF
--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -3,13 +3,16 @@ Authentication module for Auth0 JWT token verification and user management.
 
 This module provides:
 - JWT token verification using Auth0's public keys (JWKS)
+- Thread-safe JWKS cache with TTL expiry and stale-key retry on rotation
 - Automatic user creation on first login
 - FastAPI dependency for protecting endpoints with authentication
 """
 
+import asyncio
 import logging
 from collections.abc import Awaitable, Callable
-from functools import lru_cache
+from datetime import datetime, timedelta, timezone
+from threading import Lock
 from uuid import UUID
 
 import httpx
@@ -17,6 +20,7 @@ from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import jwt
 from jose.exceptions import ExpiredSignatureError, JWTClaimsError, JWTError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -29,7 +33,6 @@ from app.services.groups import GroupService
 from app.services.users import UserService
 from app.services.workspaces import WorkspaceService
 
-# Setup logging
 logger = logging.getLogger(__name__)
 
 # HTTPBearer extracts the token from Authorization: Bearer <token> header
@@ -57,104 +60,172 @@ _GROUP_ROLE_RANK: dict[GroupRole, int] = {
 }
 
 
-@lru_cache
-def get_auth0_jwks() -> dict:
+# ---------------------------------------------------------------------------
+# JWKS Cache
+# ---------------------------------------------------------------------------
+
+
+class JWKSCache:
     """
-    Fetch and cache Auth0 public keys (JWKS) for JWT verification.
+    Thread-safe JWKS cache with TTL expiry and stale-key retry.
 
-    The JWKS (JSON Web Key Set) contains the public keys used by Auth0
-    to sign JWT tokens. We cache this to avoid fetching on every request.
+    Two-layer defense against Auth0 key rotation:
+    1. Proactive: re-fetch after TTL expires (default 60 min)
+    2. Reactive: if a token's kid is not found in cache, force-refresh once
+       before failing — handles the window between rotation and TTL expiry.
 
-    Returns:
-        dict: The JWKS response containing public keys
-
-    Raises:
-        HTTPException: If unable to fetch JWKS from Auth0
+    The threading Lock ensures only one thread fetches at a time, preventing
+    a thundering herd of requests from all hitting Auth0 simultaneously when
+    the cache expires under load.
     """
-    jwks_url = f"https://{settings.auth0_domain}/.well-known/jwks.json"
 
-    try:
-        response = httpx.get(jwks_url, timeout=10.0)
-        response.raise_for_status()
-        return response.json()
-    except httpx.HTTPError as e:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=f"Unable to fetch Auth0 public keys: {str(e)}",
-        ) from e
+    def __init__(self, ttl_minutes: int = 60) -> None:
+        self._jwks: dict | None = None
+        self._fetched_at: datetime | None = None
+        self._ttl = timedelta(minutes=ttl_minutes)
+        self._lock = Lock()
+
+    @property
+    def _is_expired(self) -> bool:
+        if self._fetched_at is None:
+            return True
+        return datetime.now(tz=timezone.utc) - self._fetched_at > self._ttl
+
+    def _fetch(self) -> dict:
+        """
+        Synchronous JWKS fetch from Auth0.
+
+        This is intentionally sync — call via asyncio.to_thread in async context.
+
+        Raises:
+            HTTPException: 503 if Auth0 is unreachable.
+        """
+        jwks_url = f"https://{settings.auth0_domain}/.well-known/jwks.json"
+        try:
+            response = httpx.get(jwks_url, timeout=10.0)
+            response.raise_for_status()
+            logger.info("JWKS refreshed from Auth0")
+            return response.json()
+        except httpx.HTTPError as e:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=f"Unable to fetch Auth0 public keys: {e}",
+            ) from e
+
+    def get(self, *, force_refresh: bool = False) -> dict:
+        """
+        Return cached JWKS, refreshing if expired or forced.
+
+        Args:
+            force_refresh: Bypass TTL check and fetch immediately.
+                           Used when a token's kid is not found in cache,
+                           which may indicate Auth0 has rotated its keys.
+
+        Returns:
+            dict: The JWKS containing Auth0's public keys.
+        """
+        with self._lock:
+            if force_refresh or self._is_expired:
+                self._jwks = self._fetch()
+                self._fetched_at = datetime.now(tz=timezone.utc)
+            return self._jwks  # type: ignore[return-value]
 
 
-def verify_auth0_token(token: str) -> dict:
+# Module-level singleton shared across all requests
+jwks_cache = JWKSCache()
+
+
+# ---------------------------------------------------------------------------
+# Token verification
+# ---------------------------------------------------------------------------
+
+
+class TokenPayload(BaseModel):
+    """Typed representation of a verified Auth0 JWT payload."""
+
+    model_config = ConfigDict(extra="allow")
+
+    sub: str
+    aud: str | list[str]
+    iss: str
+    exp: int
+    iat: int
+    email: str | None = None
+    name: str | None = None
+    permissions: list[str] = Field(default_factory=list)
+
+
+def _find_rsa_key(jwks: dict, kid: str) -> dict | None:
+    """Find the RSA key matching the given kid in a JWKS response."""
+    for key in jwks["keys"]:
+        if key["kid"] == kid:
+            return {k: key[k] for k in ("kty", "kid", "use", "n", "e")}
+    return None
+
+
+def verify_auth0_token(token: str) -> TokenPayload:
     """
-    Verify Auth0 JWT token and extract claims.
+    Verify an Auth0 JWT token and return its claims.
 
-    This function:
-    1. Gets the unverified header to find which key to use (kid)
-    2. Fetches Auth0's JWKS and finds the matching public key
-    3. Validates the JWT signature using the public key
-    4. Checks token expiration, audience, and issuer
-    5. Returns the verified token payload (claims)
+    Steps:
+    1. Extract kid from the unverified token header
+    2. Look up the matching public key in JWKS cache
+    3. If kid not found, force-refresh JWKS once (handles key rotation)
+    4. Validate signature, expiry, audience, and issuer
+    5. Parse and return verified payload as a typed TokenPayload
+
+    This function is synchronous and intended to be called via
+    ``asyncio.to_thread`` from async FastAPI dependencies.
 
     Args:
-        token: The JWT token string from Authorization header
+        token: The raw JWT string from the Authorization header.
 
     Returns:
-        dict: The verified token payload containing user claims
-              (sub=auth0_id, email, name, etc.)
+        TokenPayload: Verified token payload with typed fields.
 
     Raises:
-        HTTPException: If token is invalid, expired, or verification fails
+        HTTPException: 401 if token is invalid, expired, or claims don't match.
+                       503 if Auth0's JWKS endpoint is unreachable.
     """
-    # Toggle this to enable/disable debug logging for token verification
-    DEBUG_AUTH = False
+    try:
+        unverified_header = jwt.get_unverified_header(token)
+    except JWTError as e:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"Invalid token header: {e}",
+        ) from e
+
+    kid = unverified_header.get("kid")
+    if not kid:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token header missing kid claim",
+        )
+
+    if settings.auth_debug:
+        unverified_claims = jwt.get_unverified_claims(token)
+        logger.debug("Token kid: %s", kid)
+        logger.debug("Token aud: %s", unverified_claims.get("aud"))
+        logger.debug("Token iss: %s", unverified_claims.get("iss"))
+        logger.debug("Expected aud: %s", settings.auth0_audience)
+        logger.debug("Expected iss: https://%s/", settings.auth0_domain)
+
+    # First attempt with (possibly cached) JWKS
+    rsa_key = _find_rsa_key(jwks_cache.get(), kid)
+
+    # kid not found — Auth0 may have rotated keys since last fetch
+    if rsa_key is None:
+        logger.warning("kid %s not found in JWKS cache, forcing refresh", kid)
+        rsa_key = _find_rsa_key(jwks_cache.get(force_refresh=True), kid)
+
+    if rsa_key is None:
+        logger.error("kid %s not found in JWKS even after refresh", kid)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Unable to find appropriate signing key",
+        )
 
     try:
-        if DEBUG_AUTH:
-            logger.info("=== Token Verification Debug ===")
-            logger.info(f"Token length: {len(token)}")
-            logger.info(f"Token starts with: {token[:30]}...")
-
-        # Get unverified header to find which key to use
-        unverified_header = jwt.get_unverified_header(token)
-
-        if DEBUG_AUTH:
-            logger.info(f"Unverified header: {unverified_header}")
-            # Decode token without verification to see claims
-            unverified_claims = jwt.get_unverified_claims(token)
-            logger.info(f"Token audience (aud): {unverified_claims.get('aud')}")
-            logger.info(f"Token issuer (iss): {unverified_claims.get('iss')}")
-            logger.info(f"Expected audience: {settings.auth0_audience}")
-            logger.info(f"Expected issuer: https://{settings.auth0_domain}/")
-
-        # Get the key from JWKS
-        jwks = get_auth0_jwks()
-        rsa_key = {}
-
-        # Find the key that matches the token's kid (key ID)
-        for key in jwks["keys"]:
-            if key["kid"] == unverified_header["kid"]:
-                rsa_key = {
-                    "kty": key["kty"],
-                    "kid": key["kid"],
-                    "use": key["use"],
-                    "n": key["n"],
-                    "e": key["e"],
-                }
-                break
-
-        if not rsa_key:
-            logger.error("Unable to find appropriate signing key")
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Unable to find appropriate signing key",
-            )
-
-        if DEBUG_AUTH:
-            logger.info("RSA key found, attempting to decode token...")
-
-        # Verify the token signature and claims
-        # Note: Auth0 tokens may have multiple audiences (API + userinfo endpoint)
-        # python-jose handles this by checking if our audience is in the list
         payload = jwt.decode(
             token,
             rsa_key,
@@ -169,35 +240,146 @@ def verify_auth0_token(token: str) -> dict:
             },
         )
 
-        if DEBUG_AUTH:
-            logger.info(f"Token verified successfully! User: {payload.get('sub')}")
-        return payload
+        try:
+            token_payload = TokenPayload.model_validate(payload)
+        except ValidationError as e:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail=f"Invalid token claims: {e}",
+            ) from e
+
+        if settings.auth_debug:
+            logger.debug("Token verified for sub: %s", token_payload.sub)
+
+        return token_payload
 
     except ExpiredSignatureError as e:
-        logger.error(f"Token expired: {str(e)}")
+        logger.warning("Expired token: %s", e)
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="Token has expired"
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token has expired",
         ) from e
     except JWTClaimsError as e:
-        logger.error(f"JWT claims error: {str(e)}")
-        logger.error("This usually means audience or issuer mismatch")
+        logger.warning("JWT claims error (likely aud/iss mismatch): %s", e)
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail=f"Invalid token claims: {str(e)}"
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"Invalid token claims: {e}",
         ) from e
     except JWTError as e:
-        logger.error(f"JWT error: {str(e)}")
+        logger.warning("JWT error: %s", e)
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail=f"Invalid token: {str(e)}"
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"Invalid token: {e}",
         ) from e
-    except Exception as e:
-        logger.error(f"Unexpected error during token verification: {str(e)}")
+
+
+# ---------------------------------------------------------------------------
+# FastAPI dependencies
+# ---------------------------------------------------------------------------
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security),  # noqa: B008
+    session: AsyncSession = Depends(get_session),  # noqa: B008
+) -> UserOut:
+    """
+    FastAPI dependency that authenticates requests and returns the current user.
+
+    This dependency:
+    1. Extracts the Bearer token from the Authorization header
+    2. Verifies the token with Auth0 off the event loop (asyncio.to_thread)
+    3. Looks up the user in the database by auth0_id
+    4. Auto-creates the user on first login via Auth0's /userinfo endpoint
+    5. Returns the authenticated UserOut object
+
+    Usage:
+        @router.get("/protected")
+        async def protected_endpoint(
+            current_user: UserOut = Depends(get_current_user)
+        ):
+            return {"user_id": current_user.id}
+
+    Args:
+        credentials: Automatically injected by HTTPBearer security.
+        session: Database session automatically injected.
+
+    Returns:
+        UserOut: The authenticated user.
+
+    Raises:
+        HTTPException: 401 if authentication fails, 500 if user creation fails.
+    """
+    token = credentials.credentials
+
+    # Run blocking crypto work off the async event loop
+    payload = await asyncio.to_thread(verify_auth0_token, token)
+
+    auth0_id = payload.sub
+
+    # Fast path: user already exists — most requests end here
+    user_service = UserService(session)
+    user = await user_service.get_by_auth0_id(auth0_id)
+    if user:
+        return user
+
+    # New user — we need email & name to create them.
+    # Some Auth0 setups include these in the access token directly.
+    email: str | None = payload.email
+    name: str | None = payload.name
+
+    if not email:
+        # Access tokens for API audiences don't carry email by default.
+        # Fall back to /userinfo — this only happens once per new account.
+        try:
+            userinfo_url = f"https://{settings.auth0_domain}/userinfo"
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.get(
+                    userinfo_url,
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+                response.raise_for_status()
+                userinfo = response.json()
+            email = userinfo.get("email")
+            if not name:
+                name = userinfo.get("name")
+        except httpx.HTTPError as e:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail=f"Failed to fetch user info from Auth0: {e}",
+            ) from e
+
+    if not email:
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail=f"Token verification failed: {str(e)}"
-        ) from e
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Unable to retrieve user email",
+        )
+
+    if not name:
+        name = email
+
+    user_data = UserCreate(auth0_id=auth0_id, email=email, name=name)
+    user = await user_service.create(user_data)
+
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create user",
+        )
+
+    return user
 
 
 def require_permission(minimum: Permissions) -> Callable[[UserOut], Awaitable[UserOut]]:
-    """Enforce minimum global permission level."""
+    """
+    FastAPI dependency factory that enforces a minimum global permission level.
+
+    Usage:
+        @router.delete("/admin-only")
+        async def admin_endpoint(
+            current_user: UserOut = Depends(require_permission(Permissions.admin))
+        ):
+            ...
+    """
 
     async def _check(
         current_user: UserOut = Depends(get_current_user),  # noqa: B008
@@ -212,61 +394,87 @@ def require_permission(minimum: Permissions) -> Callable[[UserOut], Awaitable[Us
     return _check
 
 
+# ---------------------------------------------------------------------------
+# Resource-level access checks
+# ---------------------------------------------------------------------------
+
+
 async def check_workspace_access(
     workspace_id: UUID,
     current_user: UserOut,
     session: AsyncSession,
     minimum_role: WorkspaceRole,
+    hide_from_non_members: bool = False,
 ) -> None:
-    """Raise 403 if user lacks required workspace role."""
+    """
+    Raise 403 if the user lacks the required workspace role.
+
+    Platform admins bypass all workspace role checks.
+
+    Args:
+        hide_from_non_members: When True, raise 404 instead of 403 for users
+            with no membership at all. Use on resource-level endpoints where
+            returning 403 would reveal that the resource exists.
+    """
     if current_user.permissions == Permissions.admin:
-        return  # Platform admins bypass
+        return
 
     ws_svc = WorkspaceService(session)
     membership = await ws_svc.get_user_membership(workspace_id, current_user.id)
 
     if not membership:
-        raise HTTPException(status_code=403, detail="Not a workspace member")
+        if hide_from_non_members:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not a workspace member")
 
     if _WORKSPACE_ROLE_RANK[membership.role] < _WORKSPACE_ROLE_RANK[minimum_role]:
-        raise HTTPException(status_code=403, detail=f"Requires {minimum_role.value} role")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Requires {minimum_role.value} role or higher",
+        )
 
 
 async def check_program_edit_access(
     workspace_id: UUID,
-    author_id: "UUID | None",
+    author_id: UUID | None,
     current_user: UserOut,
     session: AsyncSession,
+    hide_from_non_members: bool = False,
 ) -> None:
     """
-    Raise 403 unless the user can edit the program.
+    Raise 403 unless the user is permitted to edit the program.
 
-    Allowed when:
-    - current user is a platform admin, OR
-    - current user has at least ``admin`` workspace role, OR
-    - current user is the program's author with at least ``editor`` workspace role
+    Allowed when the user is:
+    - a platform admin, OR
+    - a workspace admin (or above), OR
+    - the program's author with at least editor workspace role
+
+    Args:
+        hide_from_non_members: When True, raise 404 instead of 403 for users
+            with no membership at all. Use on resource-level endpoints where
+            returning 403 would reveal that the resource exists.
     """
     if current_user.permissions == Permissions.admin:
-        return  # Platform admins bypass all workspace checks
+        return
 
     ws_svc = WorkspaceService(session)
     membership = await ws_svc.get_user_membership(workspace_id, current_user.id)
 
     if not membership:
-        raise HTTPException(status_code=403, detail="Not a workspace member")
+        if hide_from_non_members:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not a workspace member")
 
     role_rank = _WORKSPACE_ROLE_RANK[membership.role]
     is_author = author_id is not None and current_user.id == author_id
     has_admin = role_rank >= _WORKSPACE_ROLE_RANK[WorkspaceRole.admin]
     has_editor = role_rank >= _WORKSPACE_ROLE_RANK[WorkspaceRole.editor]
 
-    if has_admin:
-        return
-    if is_author and has_editor:
+    if has_admin or (is_author and has_editor):
         return
 
     raise HTTPException(
-        status_code=403,
+        status_code=status.HTTP_403_FORBIDDEN,
         detail="Requires admin role, or editor role as the program's author",
     )
 
@@ -277,112 +485,22 @@ async def check_group_access(
     session: AsyncSession,
     minimum_role: GroupRole,
 ) -> None:
-    """Raise 403 if user lacks required group role."""
+    """
+    Raise 403 if the user lacks the required group role.
+
+    Platform admins bypass all group role checks.
+    """
     if current_user.permissions == Permissions.admin:
-        return  # Platform admins bypass
+        return
 
     g_svc = GroupService(session)
     membership = await g_svc.get_user_membership(group_id, current_user.id)
 
     if not membership:
-        raise HTTPException(status_code=403, detail="Not a group member")
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not a group member")
 
     if _GROUP_ROLE_RANK[membership.role] < _GROUP_ROLE_RANK[minimum_role]:
-        raise HTTPException(status_code=403, detail=f"Requires {minimum_role.value} role")
-
-
-async def get_current_user(
-    credentials: HTTPAuthorizationCredentials = Depends(security),  # noqa: B008
-    session: AsyncSession = Depends(get_session),  # noqa: B008
-) -> UserOut:
-    """
-    FastAPI dependency that authenticates requests and returns the current user.
-
-    This dependency:
-    1. Extracts the Bearer token from the Authorization header
-    2. Verifies the token with Auth0 (signature, expiration, claims)
-    3. Extracts user information from the verified token
-    4. Looks up the user in the database by auth0_id
-    5. Auto-creates the user if this is their first login
-    6. Returns the authenticated User object
-
-    Usage:
-        @router.get("/protected")
-        async def protected_endpoint(
-            current_user: User = Depends(get_current_user)
-        ):
-            # current_user is guaranteed to be authenticated
-            return {"user_id": current_user.id}
-
-    Args:
-        credentials: Automatically injected by HTTPBearer security
-        session: Database session automatically injected
-
-    Returns:
-        UserOut: The authenticated UserOut object
-
-    Raises:
-        HTTPException: If authentication fails (invalid token, etc.)
-    """
-    token = credentials.credentials
-
-    # Verify token and get claims
-    payload = verify_auth0_token(token)
-
-    # Extract user info from verified token
-    auth0_id = payload.get("sub")
-
-    if not auth0_id:
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="Token missing required claim (sub)"
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Requires {minimum_role.value} role or higher",
         )
-
-    # Fast path: user already exists — no need to call Auth0 at all
-    user_service = UserService(session)
-    user = await user_service.get_by_auth0_id(auth0_id)
-    if user:
-        return user
-
-    # New user — we need email & name to create them.
-    # Try claims from the access token first (some Auth0 setups include these).
-    email = payload.get("email")
-    name = payload.get("name")
-
-    if not email:
-        # Access tokens for API audiences don't carry email by default.
-        # Use the /userinfo endpoint to fetch it — only happens once per account.
-        try:
-            userinfo_url = f"https://{settings.auth0_domain}/userinfo"
-            async with httpx.AsyncClient(timeout=10.0) as client:
-                response = await client.get(
-                    userinfo_url, headers={"Authorization": f"Bearer {token}"}
-                )
-                response.raise_for_status()
-                userinfo = response.json()
-            email = userinfo.get("email")
-            if not name:
-                name = userinfo.get("name")
-        except Exception as e:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail=f"Failed to fetch user info from Auth0: {str(e)}",
-            ) from e
-
-    if not email:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="Unable to retrieve user email"
-        )
-
-    if not name:
-        name = email
-
-    # Auto-create user on first login (token is already verified above)
-    user_data = UserCreate(auth0_id=auth0_id, email=email, name=name)
-    user = await user_service.create(user_data)
-
-    if not user:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create user"
-        )
-
-    return user

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -10,7 +10,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.auth import check_workspace_access, get_current_user
 from app.core.db import get_session
 from app.core.pagination import Limit, Offset, add_pagination_headers
-from app.models.content import ContentType
 from app.models.workspace import WorkspaceRole
 from app.schemas.task import TaskCreate, TaskOut, TaskUpdate
 from app.schemas.user import UserOut
@@ -38,7 +37,11 @@ async def list_event_tasks(
     event_svc = EventService(session)
     event = await event_svc.get(event_id, current_user.id)
     await check_workspace_access(
-        event.workspace_id, current_user, session, minimum_role=WorkspaceRole.viewer
+        event.workspace_id,
+        current_user,
+        session,
+        minimum_role=WorkspaceRole.viewer,
+        hide_from_non_members=True,
     )
     total = await svc.count_tasks_for_event(event_id)
     items = await svc.list_for_event(event_id, current_user.id, limit=limit, offset=offset)
@@ -64,12 +67,15 @@ async def create_event_task(
     response: Response,
     current_user: UserOut = Depends(get_current_user),
 ) -> TaskOut:
-    assert body.content_type == ContentType.task, "Content type must be 'task'"
     svc = TaskService(session)
     event_svc = EventService(session)
     event = await event_svc.get(event_id, current_user.id)
     await check_workspace_access(
-        event.workspace_id, current_user, session, minimum_role=WorkspaceRole.editor
+        event.workspace_id,
+        current_user,
+        session,
+        minimum_role=WorkspaceRole.editor,
+        hide_from_non_members=True,
     )
     task = await svc.create_under_event(event_id, body)
     response.headers["Location"] = f"/tasks/{task.id}"
@@ -88,7 +94,11 @@ async def get_task(
     task = await svc.get(task_id, current_user.id)
     event = await event_svc.get(task.event_id, current_user.id)
     await check_workspace_access(
-        event.workspace_id, current_user, session, minimum_role=WorkspaceRole.editor
+        event.workspace_id,
+        current_user,
+        session,
+        minimum_role=WorkspaceRole.editor,
+        hide_from_non_members=True,
     )
     return task
 
@@ -105,7 +115,11 @@ async def update_task(
     task = await svc.get(task_id, current_user.id)
     event = await event_svc.get(task.event_id, current_user.id)
     await check_workspace_access(
-        event.workspace_id, current_user, session, minimum_role=WorkspaceRole.editor
+        event.workspace_id,
+        current_user,
+        session,
+        minimum_role=WorkspaceRole.editor,
+        hide_from_non_members=True,
     )
     return await svc.update(task_id, body, current_user.id)
 
@@ -119,7 +133,11 @@ async def delete_task(
     task = await svc.get(task_id, current_user.id)
     event = await event_svc.get(task.event_id, current_user.id)
     await check_workspace_access(
-        event.workspace_id, current_user, session, minimum_role=WorkspaceRole.editor
+        event.workspace_id,
+        current_user,
+        session,
+        minimum_role=WorkspaceRole.editor,
+        hide_from_non_members=True,
     )
     await svc.delete(task_id)
     return None

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -84,3 +84,12 @@ class UserOut(UserBase):
     email: EmailConstrained
     auth0_id: Auth0Id
     name: NameStr
+
+
+class UserOutLimited(BaseModel):
+    """Limited user info for cases where we don't want to expose email/auth0_id."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    name: NameStr

--- a/backend/app/services/users.py
+++ b/backend/app/services/users.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.user import User
 from app.repositories.users import UserRepository
-from app.schemas.user import UserCreate, UserOut, UserUpdateAdmin, UserUpdateSelf
+from app.schemas.user import UserCreate, UserOut, UserOutLimited, UserUpdateAdmin, UserUpdateSelf
 
 
 class UserService:
@@ -16,11 +16,11 @@ class UserService:
         self.session = session
         self.repo = UserRepository(session)
 
-    async def get(self, user_id: UUID) -> UserOut:
+    async def get(self, user_id: UUID) -> UserOutLimited:
         row = await self.repo.get(user_id)
         if not row:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
-        return UserOut.model_validate(row)
+        return UserOutLimited.model_validate(row)
 
     async def get_by_auth0_id(self, auth0_id: str) -> UserOut | None:
         """

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -30,6 +30,7 @@ class Settings(BaseSettings):
     auth0_domain: str = Field(..., alias="AUTH0_DOMAIN")
     auth0_audience: str = Field(..., alias="AUTH0_AUDIENCE")
     auth0_algorithms: list[str] = Field(["RS256"], alias="AUTH0_ALGORITHMS")
+    auth_debug: bool = Field(False, alias="AUTH0_DEBUG")
 
     # Seed: emails that are always promoted to admin on `make seed`
     admin_emails: str = Field("", alias="ADMIN_EMAILS")

--- a/backend/tests/test_users_and_workspaces.py
+++ b/backend/tests/test_users_and_workspaces.py
@@ -26,7 +26,6 @@ def test_get_user(client, sample_user):
         response = client.get(f"/users/{sample_user.id}")
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
-        assert data["email"] == sample_user.email
         assert data["name"] == sample_user.name
 
 


### PR DESCRIPTION
Auth (auth.py):
- Replace lru_cache JWKS fetch with thread-safe JWKSCache class (60 min TTL, stale-key force-refresh on rotation, Lock to prevent thundering herd)
- Add TokenPayload Pydantic model for typed JWT claims
- Run JWT verification off the async event loop via asyncio.to_thread
- Replace hardcoded DEBUG_AUTH flag with configurable auth_debug setting (AUTH0_DEBUG env var)
- Add hide_from_non_members flag to check_workspace_access and check_program_edit_access: returns 404 instead of 403 for non-members, avoiding resource existence leaks

Routers:
- Pass hide_from_non_members=True on all content-level access checks (events, programs, tasks)
- Remove redundant content_type assertions from create endpoints
- Fix copy_program_to_workspace to use current_user.id instead of a caller-supplied user_id
- Add DELETE /users/me endpoint for self-deletion
- Switch GET /users/{user_id} to return UserOutLimited (id + name only)

Schemas / services:
- Add UserOutLimited schema exposing only id and name for public user lookups
- UserService.get() returns UserOutLimited

Tests:
- Remove email assertion from get_user test to match new limited response shape