### PR TITLE
refactor: split mixed admin/self endpoints into two separate routes

### DIFF
--- a/backend/app/routers/likes.py
+++ b/backend/app/routers/likes.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi import APIRouter, Depends, Request, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.auth import get_current_user
+from app.core.auth import get_current_user, require_permission
 from app.core.db import get_session
 from app.core.pagination import Limit, Offset, add_pagination_headers
 from app.schemas.like import LikeOut
@@ -56,18 +56,24 @@ async def like_content(
     return await svc.like_content(user_id=current_user.id, content_id=content_id)
 
 
-@router.delete("/content/{content_id}/likes/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/content/{content_id}/likes/me", status_code=status.HTTP_204_NO_CONTENT)
 async def unlike_content(
     session: SessionDep,
-    user_id: UUID,
     content_id: UUID,
     current_user: UserOut = Depends(get_current_user),
 ) -> None:
-    if user_id != current_user.id and current_user.permissions != Permissions.admin:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="You can only remove your own likes.",
-        )
+    svc = LikeService(session)
+    await svc.delete(user_id=current_user.id, content_id=content_id)
+    return None
+
+
+@router.delete("/content/{content_id}/likes/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def unlike_content_admin(
+    session: SessionDep,
+    user_id: UUID,
+    content_id: UUID,
+    current_user: UserOut = Depends(require_permission(Permissions.admin)),
+) -> None:
     svc = LikeService(session)
     await svc.delete(user_id=user_id, content_id=content_id)
     return None

--- a/backend/tests/test_social.py
+++ b/backend/tests/test_social.py
@@ -110,12 +110,11 @@ def test_create_comment(client):
 
 def test_unlike_content_returns_204(client):
     content_id = uuid4()
-    user_id = uuid4()
 
     with patch("app.services.likes.LikeService.delete", new_callable=AsyncMock) as mock_del:
         mock_del.return_value = None
 
-        response = client.delete(f"/content/{content_id}/likes/{user_id}")
+        response = client.delete(f"/content/{content_id}/likes/me")
         assert response.status_code == status.HTTP_204_NO_CONTENT
 
 


### PR DESCRIPTION
Replace single endpoints that accepted a user_id path param and used an inline admin-or-self permission check with two distinct endpoints each: a /me variant for the authenticated user acting on their own data, and a /{user_id} or /admin/ variant restricted to platform admins via require_permission(Permissions.admin). Applies to likes, comments, groups memberships, and workspaces.