### PR TITLE
feat: add tag_names support to content create/update

### DIFF
--- a/backend/app/repositories/tags.py
+++ b/backend/app/repositories/tags.py
@@ -127,3 +127,30 @@ class TagRepository(Repository):
             )
         )
         return res.rowcount or 0
+
+    async def add_content_tags_by_names(
+        self, content_id: UUID, names: Sequence[str]
+    ) -> Sequence[str]:
+        """Add tags by name. Returns any names not found."""
+        not_found = []
+        for name in names:
+            tag = await self.get_by_name(name)
+            if tag is None:
+                not_found.append(name)
+                continue
+            await self.add_content_tag(content_id, tag.id)
+        return not_found
+
+    async def set_content_tags_by_names(
+        self, content_id: UUID, names: Sequence[str]
+    ) -> Sequence[str]:
+        """Replace all tags for content_id. Returns any names not found."""
+        await self.session.execute(delete(ContentTag).where(ContentTag.content_id == content_id))
+        not_found = []
+        for name in names:
+            tag = await self.get_by_name(name)
+            if tag is None:
+                not_found.append(name)
+                continue
+            self.session.add(ContentTag(content_id=content_id, tag_id=tag.id))
+        return not_found

--- a/backend/app/schemas/content.py
+++ b/backend/app/schemas/content.py
@@ -72,7 +72,7 @@ class ContentBase(BaseModel):
 
 
 class ContentCreate(ContentBase):
-    pass
+    tag_names: list[str] | None = None
 
 
 class ContentUpdate(BaseModel):
@@ -88,6 +88,7 @@ class ContentUpdate(BaseModel):
     count: int | None = None
     price: int | None = None
     prep_time: DurationStr | None = None
+    tag_names: list[str] | None = None
 
     @field_validator("count", "price")
     @classmethod

--- a/backend/app/services/programs.py
+++ b/backend/app/services/programs.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.program import Program
 from app.repositories.programs import ProgramRepository
+from app.repositories.tags import TagRepository
 from app.schemas.program import ProgramCreate, ProgramOut, ProgramUpdate
 
 logger = logging.getLogger(__name__)
@@ -47,8 +48,18 @@ class ProgramService:
 
     async def create_under_workspace(self, workspace_id: UUID, data: ProgramCreate) -> ProgramOut:
         try:
-            program = Program(workspace_id=workspace_id, **data.model_dump())
+            tag_names = data.tag_names or []
+            program = Program(workspace_id=workspace_id, **data.model_dump(exclude={"tag_names"}))
             await self.repo.create(program)
+            await self.session.flush()  # populate program.id before using it in FK
+            if tag_names:
+                tag_repo = TagRepository(self.session)
+                not_found = await tag_repo.add_content_tags_by_names(program.id, tag_names)
+                if not_found:
+                    raise HTTPException(
+                        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                        detail=f"Unknown tags: {not_found}",
+                    )
             await self.session.commit()
 
             fetched = await self.repo.get(program.id)
@@ -90,9 +101,17 @@ class ProgramService:
             logger.error(f"Program {program_id} not found")
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Program not found")
         prog, _ = row
-        patch = data.model_dump(exclude_unset=True)
+        patch = data.model_dump(exclude_unset=True, exclude={"tag_names"})
         for k, v in patch.items():
             setattr(prog, k, v)
+        if "tag_names" in data.model_fields_set:
+            tag_repo = TagRepository(self.session)
+            not_found = await tag_repo.set_content_tags_by_names(program_id, data.tag_names or [])
+            if not_found:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=f"Unknown tags: {not_found}",
+                )
         await self.session.commit()
         updated = await self.repo.get(program_id, current_user_id)
         if not updated:

--- a/frontend/app/programs/[id]/components/ProgramDetailEdit.tsx
+++ b/frontend/app/programs/[id]/components/ProgramDetailEdit.tsx
@@ -33,11 +33,6 @@ const AGE_GROUPS = [
   "Vættaskátar",
 ];
 
-const PLACEHOLDER_TAGS = [
-  "útivist", "innileikur", "list", "sköpun",
-  "matreiðsla", "leikur", "fræðsla", "náttúrufræði",
-];
-
 // ── Types ────────────────────────────────────────────────────────────────────
 
 interface FormState {
@@ -80,8 +75,7 @@ export default function ProgramDetailEdit({
   isDeleting = false,
 }: ProgramDetailEditProps) {
   const { tagNames: fetchedTags } = useTags();
-  const displayTags =
-    fetchedTags && fetchedTags.length > 0 ? fetchedTags : PLACEHOLDER_TAGS;
+  const displayTags = fetchedTags ?? [];
 
   const [durationMin0, durationMax0] = parseDuration(program.duration);
   const [prepMin0, prepMax0] = parseDuration(program.prep_time);
@@ -178,6 +172,7 @@ export default function ProgramDetailEdit({
       location: form.location.trim() || null,
       count: form.countMin !== "" ? Number(form.countMin) : null,
       price: form.price !== "" ? Number(form.price) : null,
+      tagNames: form.selectedTags,
     };
 
     try {
@@ -469,27 +464,33 @@ export default function ProgramDetailEdit({
             <p className={styles.label} id="edit-tags-label">
               Merkimiðar
             </p>
-            <div className={styles.tagGrid} role="group" aria-labelledby="edit-tags-label">
-              {displayTags.map((tag) => {
-                const isSelected = form.selectedTags.includes(tag);
-                return (
-                  <button
-                    key={tag}
-                    type="button"
-                    className={`${styles.tagButton} ${isSelected ? styles.tagButtonActive : ""}`}
-                    onClick={() => toggleTag(tag)}
-                    aria-pressed={isSelected}
-                    disabled={isDisabled}
-                  >
-                    {tag}
-                  </button>
-                );
-              })}
-            </div>
-            {form.selectedTags.length > 0 && (
-              <p className={styles.helpText}>
-                {form.selectedTags.length} merkimiðar valdir
-              </p>
+            {displayTags.length === 0 ? (
+              <p className={styles.helpText}>Engir merkimiðar tiltækir</p>
+            ) : (
+              <>
+                <div className={styles.tagGrid} role="group" aria-labelledby="edit-tags-label">
+                  {displayTags.map((tag) => {
+                    const isSelected = form.selectedTags.includes(tag);
+                    return (
+                      <button
+                        key={tag}
+                        type="button"
+                        className={`${styles.tagButton} ${isSelected ? styles.tagButtonActive : ""}`}
+                        onClick={() => toggleTag(tag)}
+                        aria-pressed={isSelected}
+                        disabled={isDisabled}
+                      >
+                        {tag}
+                      </button>
+                    );
+                  })}
+                </div>
+                {form.selectedTags.length > 0 && (
+                  <p className={styles.helpText}>
+                    {form.selectedTags.length} merkimiðar valdir
+                  </p>
+                )}
+              </>
             )}
           </div>
 

--- a/frontend/app/programs/components/NewProgramForm.tsx
+++ b/frontend/app/programs/components/NewProgramForm.tsx
@@ -70,11 +70,6 @@ const AGE_GROUPS = [
   "Vættaskátar",
 ];
 
-const PLACEHOLDER_TAGS = [
-  "útivist", "innileikur", "list", "sköpun",
-  "matreiðsla", "leikur", "fræðsla", "náttúrufræði",
-];
-
 // ── Props ────────────────────────────────────────────────────────────────────
 
 type Props = {
@@ -88,7 +83,7 @@ type Props = {
 export default function NewProgramForm({ workspaceId, onCreated, onCancel }: Props) {
   const { getToken } = useAuth();
   const { tagNames: availableTags } = useTags();
-  const displayTags = availableTags && availableTags.length > 0 ? availableTags : PLACEHOLDER_TAGS;
+  const displayTags = availableTags ?? [];
 
   // Draft state — workspace-scoped key so drafts don't bleed between workspaces
   const draftKey = `prog-draft-${workspaceId}`;
@@ -118,7 +113,6 @@ export default function NewProgramForm({ workspaceId, onCreated, onCancel }: Pro
     } catch {
       // ignore
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [draftKey]);
 
   // ── Accordion helpers ──────────────────────────────────────────────────────
@@ -243,7 +237,7 @@ export default function NewProgramForm({ workspaceId, onCreated, onCancel }: Pro
           location: draft.location.trim() || undefined,
           count: draft.countMin !== "" ? Number(draft.countMin) : undefined,
           price: draft.price !== "" ? Number(draft.price) : undefined,
-          tags: draft.selectedTags.length > 0 ? draft.selectedTags : undefined,
+          tagNames: draft.selectedTags.length > 0 ? draft.selectedTags : undefined,
           workspaceId,
         },
         getToken
@@ -685,29 +679,35 @@ function SectionExtras({ draft, updateDraft, displayTags }: SectionExtrasProps) 
   return (
     <>
       <div className={styles.field}>
-        <div className={styles.tagGrid}>
-          {displayTags.map((tag) => {
-            const isSelected = draft.selectedTags.includes(tag);
-            return (
-              <button
-                key={tag}
-                type="button"
-                className={`${styles.tagButton} ${isSelected ? styles.tagButtonActive : ""}`}
-                onClick={() => {
-                  const next = isSelected
-                    ? draft.selectedTags.filter((t) => t !== tag)
-                    : [...draft.selectedTags, tag];
-                  updateDraft({ selectedTags: next });
-                }}
-                aria-pressed={isSelected}
-              >
-                {tag}
-              </button>
-            );
-          })}
-        </div>
-        {draft.selectedTags.length > 0 && (
-          <p className={styles.hint}>{draft.selectedTags.length} merkimiðar valdir</p>
+        {displayTags.length === 0 ? (
+          <p className={styles.hint}>Engir merkimiðar tiltækir</p>
+        ) : (
+          <>
+            <div className={styles.tagGrid}>
+              {displayTags.map((tag) => {
+                const isSelected = draft.selectedTags.includes(tag);
+                return (
+                  <button
+                    key={tag}
+                    type="button"
+                    className={`${styles.tagButton} ${isSelected ? styles.tagButtonActive : ""}`}
+                    onClick={() => {
+                      const next = isSelected
+                        ? draft.selectedTags.filter((t) => t !== tag)
+                        : [...draft.selectedTags, tag];
+                      updateDraft({ selectedTags: next });
+                    }}
+                    aria-pressed={isSelected}
+                  >
+                    {tag}
+                  </button>
+                );
+              })}
+            </div>
+            {draft.selectedTags.length > 0 && (
+              <p className={styles.hint}>{draft.selectedTags.length} merkimiðar valdir</p>
+            )}
+          </>
         )}
       </div>
 

--- a/frontend/services/programs.service.ts
+++ b/frontend/services/programs.service.ts
@@ -1,6 +1,5 @@
 import { buildApiUrl } from "@/lib/api-utils";
 import { fetchWithAuth } from "@/lib/api";
-import { findTagIdByName, addTagToContent } from "@/services/tags.service";
 import { User } from "@/services/users.service";
 
 export type Program = {
@@ -48,7 +47,7 @@ export type ProgramCreateInput = {
   location?: string;
   count?: number;
   price?: number;
-  tags?: string[];
+  tagNames?: string[];
   workspaceId: string; // Required - workspace to create program in
 };
 
@@ -65,7 +64,7 @@ export type ProgramUpdateInput = {
   location?: string | null;
   count?: number | null;
   price?: number | null;
-  // tags are managed via separate tag-assignment endpoints
+  tagNames?: string[]; // omit to leave tags unchanged; pass [] to clear all tags
 };
 
 export type ProgramsResponse = Program[] | { programs: Program[] };
@@ -93,26 +92,6 @@ export async function fetchPrograms(
   }, getToken);
 
   return Array.isArray(data) ? data : data.programs || [];
-}
-
-/**
- * Assign tags to a program by tag names
- * Looks up tag IDs and assigns them to the program
- */
-async function assignTagsToProgram(
-  programId: string,
-  tagNames: string[],
-  getToken: () => Promise<string | null>
-): Promise<void> {
-  for (const tagName of tagNames) {
-    try {
-      const tagId = await findTagIdByName(tagName);
-      if (!tagId) continue;
-      await addTagToContent(programId, tagId, getToken);
-    } catch {
-      // Continue with other tags even if one fails
-    }
-  }
 }
 
 /**
@@ -149,6 +128,7 @@ export async function createProgram(
     location: input.location?.trim() || null,
     count: input.count ?? null,
     price: input.price ?? null,
+    tag_names: input.tagNames && input.tagNames.length > 0 ? input.tagNames : null,
     content_type: "program" as const,
   };
 
@@ -162,13 +142,7 @@ export async function createProgram(
     body: JSON.stringify(payload),
   }, getToken);
 
-  const program = Array.isArray(data) ? data[0] : data;
-
-  if (input.tags && input.tags.length > 0) {
-    await assignTagsToProgram(program.id, input.tags, getToken);
-  }
-
-  return program;
+  return Array.isArray(data) ? data[0] : data;
 }
 
 /**
@@ -180,13 +154,15 @@ export async function updateProgram(
   input: ProgramUpdateInput,
   getToken: () => Promise<string | null>
 ): Promise<Program> {
+  const { tagNames, ...rest } = input;
+  const body = tagNames !== undefined ? { ...rest, tag_names: tagNames } : rest;
   const url = buildApiUrl(`/programs/${id}`);
   return fetchWithAuth<Program>(url, {
     method: "PATCH",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify(input),
+    body: JSON.stringify(body),
   }, getToken);
 }
 


### PR DESCRIPTION
Tags can now be set atomically when creating or updating programs via `tag_names` in the request body, replacing the fragile N+1 name-lookup approach on the frontend.

Backend:
- ContentCreate and ContentUpdate schemas accept `tag_names: list[str] | None`
- TagRepository gains add_content_tags_by_names (create path) and set_content_tags_by_names (update path, atomic replace)
- ProgramService excludes tag_names from ORM dump, flushes to populate program.id, then assigns tags before commit; raises 422 on unknown names

Frontend:
- ProgramCreateInput.tags renamed to tagNames; sent as tag_names in body
- ProgramUpdateInput gains tagNames; mapped to tag_names in PATCH body
- Removed assignTagsToProgram N+1 helper and its unused imports
- NewProgramForm and ProgramDetailEdit pass tagNames in a single request; placeholder tag fallback removed in favour of an empty-state message