### PR TITLE
refactor: move workspace_id to content base, fix eager loading

### DIFF
--- a/backend/alembic/versions/abd31343eed5_.py
+++ b/backend/alembic/versions/abd31343eed5_.py
@@ -1,0 +1,52 @@
+"""move image and media to content, remove task fields
+
+Revision ID: abd31343eed5
+Revises: ed5103eb3c65
+Create Date: 2026-03-02 20:38:14.900220
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = 'abd31343eed5'
+down_revision: Union[str, Sequence[str], None] = 'ed5103eb3c65'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_index('ix_comments_content_id_created_at', 'comments', ['content_id', 'created_at'], unique=False)
+    op.create_index('ix_comments_user_id_created_at', 'comments', ['user_id', 'created_at'], unique=False)
+    op.add_column('content', sa.Column('image', sa.String(length=255), nullable=True))
+    op.add_column('content', sa.Column('media', postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+    # Migrate data: copy image from programs → content
+    op.execute("UPDATE content SET image = p.image FROM programs p WHERE p.id = content.id")
+    # Migrate data: copy media from tasks → content
+    op.execute("UPDATE content SET media = t.media FROM tasks t WHERE t.id = content.id")
+    op.drop_column('programs', 'image')
+    op.drop_column('tasks', 'participant_min')
+    op.drop_column('tasks', 'media')
+    op.drop_column('tasks', 'estimated_duration')
+    op.drop_column('tasks', 'participant_max')
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.add_column('tasks', sa.Column('participant_max', sa.INTEGER(), autoincrement=False, nullable=True))
+    op.add_column('tasks', sa.Column('estimated_duration', sa.INTEGER(), autoincrement=False, nullable=True))
+    op.add_column('tasks', sa.Column('media', postgresql.JSONB(astext_type=sa.Text()), autoincrement=False, nullable=True))
+    op.add_column('tasks', sa.Column('participant_min', sa.INTEGER(), autoincrement=False, nullable=True))
+    op.add_column('programs', sa.Column('image', sa.VARCHAR(length=255), autoincrement=False, nullable=True))
+    # Restore data: copy image from content → programs
+    op.execute("UPDATE programs SET image = c.image FROM content c WHERE c.id = programs.id")
+    # Restore data: copy media from content → tasks
+    op.execute("UPDATE tasks SET media = c.media FROM content c WHERE c.id = tasks.id")
+    op.drop_column('content', 'media')
+    op.drop_column('content', 'image')
+    op.drop_index('ix_comments_user_id_created_at', table_name='comments')
+    op.drop_index('ix_comments_content_id_created_at', table_name='comments')

--- a/backend/alembic/versions/aeaa97f45732_.py
+++ b/backend/alembic/versions/aeaa97f45732_.py
@@ -1,0 +1,28 @@
+"""add FK constraint to events.program_id
+
+Revision ID: aeaa97f45732
+Revises: c3d4e5f6a7b8
+Create Date: 2026-03-02 22:10:43.065624
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'aeaa97f45732'
+down_revision: Union[str, Sequence[str], None] = 'c3d4e5f6a7b8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_foreign_key('fk_events_program_id_programs', 'events', 'programs', ['program_id'], ['id'], ondelete='SET NULL')
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint('fk_events_program_id_programs', 'events', type_='foreignkey')

--- a/backend/alembic/versions/c3d4e5f6a7b8_.py
+++ b/backend/alembic/versions/c3d4e5f6a7b8_.py
@@ -1,0 +1,168 @@
+"""move workspace_id to content, make task event_id nullable
+
+Revision ID: c3d4e5f6a7b8
+Revises: abd31343eed5
+Create Date: 2026-03-02 21:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "c3d4e5f6a7b8"
+down_revision: Union[str, Sequence[str], None] = "abd31343eed5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # 1. Add workspace_id to content (nullable first for backfill)
+    op.add_column(
+        "content",
+        sa.Column(
+            "workspace_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+    )
+
+    # 2. Backfill: programs → content
+    op.execute(
+        "UPDATE content SET workspace_id = p.workspace_id FROM programs p WHERE p.id = content.id"
+    )
+
+    # 3. Backfill: events → content
+    op.execute(
+        "UPDATE content SET workspace_id = e.workspace_id FROM events e WHERE e.id = content.id"
+    )
+
+    # 4. Backfill: tasks → content (via task's event)
+    op.execute(
+        """
+        UPDATE content
+        SET workspace_id = e.workspace_id
+        FROM tasks t
+        JOIN events e ON e.id = t.event_id
+        WHERE content.id = t.id
+        """
+    )
+
+    # 5. Set NOT NULL on content.workspace_id
+    op.alter_column("content", "workspace_id", nullable=False)
+
+    # 6. Add FK constraint content.workspace_id → workspaces.id
+    op.create_foreign_key(
+        "fk_content_workspace_id",
+        "content",
+        "workspaces",
+        ["workspace_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+
+    # 7. Add index on content.workspace_id
+    op.create_index("ix_content_workspace_id", "content", ["workspace_id"])
+
+    # 8. Drop composite FK constraint from events
+    op.drop_constraint("fk_event_program_workspace_program", "events", type_="foreignkey")
+
+    # 9. Drop workspace_id from events
+    op.drop_column("events", "workspace_id")
+
+    # 10. Drop UniqueConstraint from programs
+    op.drop_constraint("uq_program_workspace_id_id", "programs", type_="unique")
+
+    # 11. Drop workspace_id from programs
+    op.drop_column("programs", "workspace_id")
+
+    # 12. Drop existing FK on tasks.event_id (ondelete=CASCADE)
+    op.drop_constraint("tasks_event_id_fkey", "tasks", type_="foreignkey")
+
+    # 13. Make tasks.event_id nullable
+    op.alter_column("tasks", "event_id", nullable=True)
+
+    # 14. Re-add FK on tasks.event_id with SET NULL
+    op.create_foreign_key(
+        "tasks_event_id_fkey",
+        "tasks",
+        "events",
+        ["event_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Reverse in reverse order
+
+    # 14/13/12. Restore tasks.event_id as non-nullable FK with CASCADE
+    op.drop_constraint("tasks_event_id_fkey", "tasks", type_="foreignkey")
+    op.alter_column("tasks", "event_id", nullable=False)
+    op.create_foreign_key(
+        "tasks_event_id_fkey",
+        "tasks",
+        "events",
+        ["event_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    # 11/10. Restore workspace_id on programs
+    op.add_column(
+        "programs",
+        sa.Column("workspace_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.execute(
+        "UPDATE programs SET workspace_id = c.workspace_id FROM content c WHERE c.id = programs.id"
+    )
+    op.alter_column("programs", "workspace_id", nullable=False)
+    op.create_unique_constraint(
+        "uq_program_workspace_id_id", "programs", ["workspace_id", "id"]
+    )
+    op.create_foreign_key(
+        "programs_workspace_id_fkey",
+        "programs",
+        "workspaces",
+        ["workspace_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    # 9/8. Restore workspace_id on events and composite FK
+    op.add_column(
+        "events",
+        sa.Column("workspace_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.execute(
+        "UPDATE events SET workspace_id = c.workspace_id FROM content c WHERE c.id = events.id"
+    )
+    op.alter_column("events", "workspace_id", nullable=False)
+    op.create_foreign_key(
+        "events_workspace_id_fkey",
+        "events",
+        "workspaces",
+        ["workspace_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.create_foreign_key(
+        "fk_event_program_workspace_program",
+        "events",
+        "programs",
+        ["workspace_id", "program_id"],
+        ["workspace_id", "id"],
+        ondelete="RESTRICT",
+        deferrable=True,
+        initially="DEFERRED",
+    )
+
+    # 7/6/5. Drop index, FK, and column from content
+    op.drop_index("ix_content_workspace_id", table_name="content")
+    op.drop_constraint("fk_content_workspace_id", "content", type_="foreignkey")
+    op.drop_column("content", "workspace_id")

--- a/backend/app/domain/content_constraints.py
+++ b/backend/app/domain/content_constraints.py
@@ -6,3 +6,4 @@ DURATION_MAX: Final[int] = 50
 DESC_MAX: Final[int] = 1000
 INSTRUCTIONS_MAX: Final[int] = 5000
 LOCATION_MAX: Final[int] = 255
+IMG_MAX: Final[int] = 255

--- a/backend/app/domain/event_constraints.py
+++ b/backend/app/domain/event_constraints.py
@@ -1,3 +1,0 @@
-from typing import Final
-
-LOCATION_MAX: Final[int] = 255

--- a/backend/app/domain/program_constraints.py
+++ b/backend/app/domain/program_constraints.py
@@ -1,3 +1,0 @@
-from typing import Final
-
-IMG_MAX: Final[int] = 255

--- a/backend/app/models/content.py
+++ b/backend/app/models/content.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime as dt
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
 from sqlalchemy import (
@@ -20,6 +20,7 @@ from sqlalchemy.types import Integer
 from app.domain.content_constraints import (
     DESC_MAX,
     DURATION_MAX,
+    IMG_MAX,
     INSTRUCTIONS_MAX,
     LOCATION_MAX,
     NAME_MAX,
@@ -32,6 +33,7 @@ if TYPE_CHECKING:
     from .comment import Comment
     from .tag import ContentTag, Tag
     from .user import User
+    from .workspace import Workspace
 
 
 class ContentType(str, Enum):
@@ -76,6 +78,8 @@ class Content(SoftDeleteMixin, Base):
     )
     name: Mapped[str] = mapped_column(String(NAME_MAX), nullable=False)
     description: Mapped[str | None] = mapped_column(String(DESC_MAX), nullable=True)
+    image: Mapped[str | None] = mapped_column(String(IMG_MAX), nullable=True)
+    media: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
     equipment: Mapped[list[str] | None] = mapped_column(JSONB, nullable=True)
     instructions: Mapped[str | None] = mapped_column(
         String(INSTRUCTIONS_MAX),
@@ -99,9 +103,20 @@ class Content(SoftDeleteMixin, Base):
         ForeignKey("users.id"),
         nullable=False,
     )
+    workspace_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
 
     # Relationships
     author: Mapped[User] = relationship(back_populates="authored_content")
+    workspace: Mapped[Workspace] = relationship(
+        "Workspace",
+        back_populates="content_items",
+        foreign_keys="Content.workspace_id",
+        primaryjoin="Content.workspace_id == Workspace.id",
+    )
     comments: Mapped[list[Comment]] = relationship(
         back_populates="content", cascade="all, delete-orphan"
     )
@@ -110,6 +125,10 @@ class Content(SoftDeleteMixin, Base):
     )
 
     # Properties for serialization
+    @property
+    def author_name(self) -> str:
+        return self.author.name
+
     @property
     def tags(self) -> list[Tag]:
         """Return list of Tag objects from content_tags relationship"""

--- a/backend/app/models/event.py
+++ b/backend/app/models/event.py
@@ -4,7 +4,7 @@ import datetime as dt
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from sqlalchemy import ForeignKey, ForeignKeyConstraint
+from sqlalchemy import ForeignKey
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.types import DateTime as SADateTime
@@ -15,22 +15,11 @@ if TYPE_CHECKING:
     from .program import Program
     from .task import Task
     from .troop import TroopParticipation
-    from .workspace import Workspace
 
 
 class Event(Content):
     __tablename__ = "events"
     __mapper_args__ = {"polymorphic_identity": ContentType.event}
-    __table_args__ = (  # type: ignore[assignment]
-        ForeignKeyConstraint(
-            ["workspace_id", "program_id"],
-            ["programs.workspace_id", "programs.id"],
-            name="fk_event_program_workspace_program",
-            ondelete="RESTRICT",
-            deferrable=True,
-            initially="DEFERRED",
-        ),
-    )
 
     # Columns
     id: Mapped[UUID] = mapped_column(
@@ -43,32 +32,26 @@ class Event(Content):
     start_dt: Mapped[dt.datetime] = mapped_column(SADateTime(timezone=True), nullable=False)
     end_dt: Mapped[dt.datetime | None] = mapped_column(SADateTime(timezone=True), nullable=True)
 
-    workspace_id: Mapped[UUID] = mapped_column(
+    program_id: Mapped[UUID | None] = mapped_column(
         PGUUID(as_uuid=True),
-        ForeignKey("workspaces.id", ondelete="RESTRICT"),
-        nullable=False,
+        ForeignKey("programs.id", ondelete="SET NULL"),
+        nullable=True,
     )
-    program_id: Mapped[UUID | None] = mapped_column(PGUUID(as_uuid=True), nullable=True)
 
     # Relationships
+    program: Mapped[Program | None] = relationship(
+        "Program",
+        back_populates="events",
+        foreign_keys=[program_id],
+        primaryjoin="Event.program_id == Program.id",
+    )
+
     tasks: Mapped[list[Task]] = relationship(
         "Task",
         back_populates="event",
         foreign_keys="Task.event_id",
         primaryjoin="Task.event_id == Event.id",
-        cascade="all, delete-orphan",
-    )
-
-    workspace: Mapped[Workspace] = relationship(
-        back_populates="events",
-        foreign_keys="Event.workspace_id",
-        primaryjoin="Event.workspace_id == Workspace.id",
-    )
-
-    program: Mapped[Program] = relationship(
-        back_populates="events",
-        foreign_keys="Event.program_id",
-        primaryjoin="Event.program_id == Program.id",
+        cascade="save-update, merge",
     )
 
     troop_participations: Mapped[list[TroopParticipation]] = relationship(

--- a/backend/app/models/program.py
+++ b/backend/app/models/program.py
@@ -3,23 +3,19 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from sqlalchemy import ForeignKey, String, UniqueConstraint
+from sqlalchemy import ForeignKey
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-
-from app.domain.program_constraints import IMG_MAX
 
 from .content import Content, ContentType
 
 if TYPE_CHECKING:
     from .event import Event
-    from .workspace import Workspace
 
 
 class Program(Content):
     __tablename__ = "programs"
     __mapper_args__ = {"polymorphic_identity": ContentType.program}
-    __table_args__ = (UniqueConstraint("workspace_id", "id", name="uq_program_workspace_id_id"),)  # type: ignore[assignment]
 
     # Columns
     id: Mapped[UUID] = mapped_column(
@@ -28,19 +24,12 @@ class Program(Content):
         primary_key=True,
         nullable=False,
     )
-    image: Mapped[str | None] = mapped_column(String(IMG_MAX), nullable=True)
-
-    workspace_id: Mapped[UUID] = mapped_column(
-        PGUUID(as_uuid=True),
-        ForeignKey("workspaces.id", ondelete="CASCADE"),
-        nullable=False,
-    )
 
     # Relationships
-    workspace: Mapped[Workspace] = relationship(back_populates="programs")
     events: Mapped[list[Event]] = relationship(
+        "Event",
         back_populates="program",
         foreign_keys="Event.program_id",
         primaryjoin="Event.program_id == Program.id",
-        cascade="all, delete-orphan",
+        cascade="save-update, merge",
     )

--- a/backend/app/models/task.py
+++ b/backend/app/models/task.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 from uuid import UUID
 
-from sqlalchemy import ForeignKey, Integer
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy import ForeignKey
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -26,20 +25,14 @@ class Task(Content):
         nullable=False,
     )
 
-    media: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
-
-    event_id: Mapped[UUID] = mapped_column(
+    event_id: Mapped[UUID | None] = mapped_column(
         PGUUID(as_uuid=True),
-        ForeignKey("events.id", ondelete="CASCADE"),
-        nullable=False,
+        ForeignKey("events.id", ondelete="SET NULL"),
+        nullable=True,
     )
 
-    estimated_duration: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    participant_min: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    participant_max: Mapped[int | None] = mapped_column(Integer, nullable=True)
-
     # Relationships
-    event: Mapped[Event] = relationship(
+    event: Mapped[Event | None] = relationship(
         "Event",
         back_populates="tasks",
         foreign_keys=[event_id],

--- a/backend/app/models/workspace.py
+++ b/backend/app/models/workspace.py
@@ -25,9 +25,11 @@ from app.domain.workspace_constraints import (
 from .base import Base, SoftDeleteMixin
 
 if TYPE_CHECKING:
+    from .content import Content
     from .event import Event
     from .group import Group
     from .program import Program
+    from .task import Task
     from .troop import Troop
     from .user import User
 
@@ -97,17 +99,33 @@ class Workspace(SoftDeleteMixin, Base):
         passive_deletes=True,
     )
     group: Mapped[Group | None] = relationship(back_populates="workspaces")
-    programs: Mapped[list[Program]] = relationship(
+    content_items: Mapped[list[Content]] = relationship(
+        "Content",
         back_populates="workspace",
-        foreign_keys="Program.workspace_id",
-        primaryjoin="Program.workspace_id == Workspace.id",
+        foreign_keys="Content.workspace_id",
+        primaryjoin="Content.workspace_id == Workspace.id",
         cascade="all, delete-orphan",
     )
+    programs: Mapped[list[Program]] = relationship(
+        "Program",
+        primaryjoin="Program.workspace_id == Workspace.id",
+        foreign_keys="Content.workspace_id",
+        overlaps="content_items,workspace",
+        viewonly=True,
+    )
     events: Mapped[list[Event]] = relationship(
-        back_populates="workspace",
-        foreign_keys="Event.workspace_id",
+        "Event",
         primaryjoin="Event.workspace_id == Workspace.id",
-        cascade="all, delete-orphan",
+        foreign_keys="Content.workspace_id",
+        overlaps="content_items,workspace",
+        viewonly=True,
+    )
+    tasks: Mapped[list[Task]] = relationship(
+        "Task",
+        primaryjoin="Task.workspace_id == Workspace.id",
+        foreign_keys="Content.workspace_id",
+        overlaps="content_items,workspace",
+        viewonly=True,
     )
     troops: Mapped[list[Troop]] = relationship(
         back_populates="workspace",

--- a/backend/app/repositories/events.py
+++ b/backend/app/repositories/events.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import selectinload
 
 from app.models.content import Content
 from app.models.event import Event
+from app.models.tag import ContentTag
 from app.models.task import Task
 from app.repositories.base import Repository
 from app.repositories.content import (
@@ -33,9 +34,13 @@ class EventRepository(Repository):
             .options(
                 selectinload(Event.author),
                 selectinload(Event.workspace),
-                selectinload(Event.program),
-                selectinload(Event.tasks),
-                selectinload(Event.content_tags),
+                selectinload(Event.tasks).options(
+                    selectinload(Task.author),
+                    selectinload(Task.workspace),
+                    selectinload(Task.content_tags).selectinload(ContentTag.tag),
+                ),
+                selectinload(Event.comments),
+                selectinload(Event.content_tags).selectinload(ContentTag.tag),
             )
             .where(Event.id == event_id, Event.deleted_at.is_(None))
         )
@@ -59,7 +64,13 @@ class EventRepository(Repository):
             .options(
                 selectinload(Event.author),
                 selectinload(Event.workspace),
-                selectinload(Event.content_tags),
+                selectinload(Event.tasks).options(
+                    selectinload(Task.author),
+                    selectinload(Task.workspace),
+                    selectinload(Task.content_tags).selectinload(ContentTag.tag),
+                ),
+                selectinload(Event.comments),
+                selectinload(Event.content_tags).selectinload(ContentTag.tag),
             )
             .where(
                 Event.id == event_id,
@@ -111,6 +122,11 @@ class EventRepository(Repository):
         stmt = (
             select(
                 Event, like_count_subq(), comment_count_subq(), liked_by_me_subq(current_user_id)
+            )
+            .options(
+                selectinload(Event.author),
+                selectinload(Event.workspace),
+                selectinload(Event.content_tags).selectinload(ContentTag.tag),
             )
             .where(and_(*conds))
             .order_by(asc(Event.start_dt))
@@ -171,6 +187,11 @@ class EventRepository(Repository):
             select(
                 Event, like_count_subq(), comment_count_subq(), liked_by_me_subq(current_user_id)
             )
+            .options(
+                selectinload(Event.author),
+                selectinload(Event.workspace),
+                selectinload(Event.content_tags).selectinload(ContentTag.tag),
+            )
             .where(and_(*conds))
             .order_by(asc(Event.start_dt))
             .limit(limit)
@@ -188,25 +209,11 @@ class EventRepository(Repository):
 
     async def delete(self, event_id: UUID) -> int:
         now = dt.datetime.now(dt.timezone.utc)
-        # Program/Event/Task use joined-table inheritance: each has its own
-        # table (programs/events/tasks) with a FK to `content`.  deleted_at is
-        # only on `content`, so update(Task/Event) would be a cross-table SET
-        # which PostgreSQL rejects.  We therefore:
-        #   1. Use subclass mappers (Task, Event) only for SELECT (no issue).
-        #   2. Cascade via update(Content) keyed by pre-fetched IDs (no join).
 
-        # Pre-fetch task IDs for this event
-        task_ids = list(
-            (await self.session.execute(select(Task.id).where(Task.event_id == event_id))).scalars()
+        # Orphan tasks: clear event_id so tasks remain as workspace tasks
+        await self.session.execute(
+            update(Task).where(Task.event_id == event_id).values(event_id=None)
         )
-
-        # Cascade: soft-delete tasks
-        if task_ids:
-            await self.session.execute(
-                update(Content)
-                .where(Content.id.in_(task_ids), Content.deleted_at.is_(None))
-                .values(deleted_at=now)
-            )
 
         # Soft-delete the event itself
         res = await self.session.execute(

--- a/backend/app/repositories/programs.py
+++ b/backend/app/repositories/programs.py
@@ -11,7 +11,6 @@ from app.models.content import Content
 from app.models.event import Event
 from app.models.program import Program
 from app.models.tag import ContentTag
-from app.models.task import Task
 from app.repositories.base import Repository
 from app.repositories.content import (
     ContentStats,
@@ -35,7 +34,11 @@ class ProgramRepository(Repository):
             .options(
                 selectinload(Program.author),
                 selectinload(Program.workspace),
-                selectinload(Program.events),
+                selectinload(Program.events).options(
+                    selectinload(Event.author),
+                    selectinload(Event.workspace),
+                    selectinload(Event.content_tags).selectinload(ContentTag.tag),
+                ),
                 selectinload(Program.comments),
                 selectinload(Program.content_tags).selectinload(ContentTag.tag),
             )
@@ -57,6 +60,11 @@ class ProgramRepository(Repository):
             .options(
                 selectinload(Program.author),
                 selectinload(Program.workspace),
+                selectinload(Program.events).options(
+                    selectinload(Event.author),
+                    selectinload(Event.workspace),
+                    selectinload(Event.content_tags).selectinload(ContentTag.tag),
+                ),
                 selectinload(Program.comments),
                 selectinload(Program.content_tags).selectinload(ContentTag.tag),
             )
@@ -95,7 +103,6 @@ class ProgramRepository(Repository):
             .options(
                 selectinload(Program.author),
                 selectinload(Program.workspace),
-                selectinload(Program.comments),
                 selectinload(Program.content_tags).selectinload(ContentTag.tag),
             )
             .where(Program.workspace_id == workspace_id, Program.deleted_at.is_(None))
@@ -115,44 +122,11 @@ class ProgramRepository(Repository):
 
     async def delete(self, program_id: UUID) -> int:
         now = dt.datetime.now(dt.timezone.utc)
-        # Program/Event/Task use joined-table inheritance: each has its own
-        # table (programs/events/tasks) with a FK to `content`.  deleted_at is
-        # only on `content`, so update(Task/Event) would be a cross-table SET
-        # which PostgreSQL rejects.  Strategy:
-        #   1. Use subclass mappers for SELECT only (joins are fine in SELECT).
-        #   2. Cascade via update(Content) keyed by pre-fetched IDs.
 
-        # Pre-fetch event IDs for this program
-        event_ids = list(
-            (
-                await self.session.execute(select(Event.id).where(Event.program_id == program_id))
-            ).scalars()
+        # Orphan events: clear program_id so events remain as standalone workspace events
+        await self.session.execute(
+            update(Event).where(Event.program_id == program_id).values(program_id=None)
         )
-
-        # Pre-fetch task IDs for those events
-        task_ids: list = []
-        if event_ids:
-            task_ids = list(
-                (
-                    await self.session.execute(select(Task.id).where(Task.event_id.in_(event_ids)))
-                ).scalars()
-            )
-
-        # Cascade: soft-delete tasks
-        if task_ids:
-            await self.session.execute(
-                update(Content)
-                .where(Content.id.in_(task_ids), Content.deleted_at.is_(None))
-                .values(deleted_at=now)
-            )
-
-        # Cascade: soft-delete events
-        if event_ids:
-            await self.session.execute(
-                update(Content)
-                .where(Content.id.in_(event_ids), Content.deleted_at.is_(None))
-                .values(deleted_at=now)
-            )
 
         # Soft-delete the program itself
         res = await self.session.execute(

--- a/backend/app/repositories/tags.py
+++ b/backend/app/repositories/tags.py
@@ -11,6 +11,12 @@ from sqlalchemy.orm import selectinload
 from app.models.content import Content
 from app.models.tag import ContentTag, Tag
 from app.repositories.base import Repository
+from app.repositories.content import (
+    ContentStats,
+    comment_count_subq,
+    like_count_subq,
+    liked_by_me_subq,
+)
 
 
 class TagRepository(Repository):
@@ -93,17 +99,26 @@ class TagRepository(Repository):
         return result or 0
 
     async def list_tagged_content(
-        self, tag_id: UUID, *, limit: int = 50, offset: int = 0
-    ) -> Sequence[Content]:
+        self, tag_id: UUID, current_user_id: UUID | None = None, *, limit: int = 50, offset: int = 0
+    ) -> list[tuple[Content, ContentStats]]:  # type: ignore[valid-type]
         stmt = (
-            select(Content)
+            select(Content, like_count_subq(), comment_count_subq(), liked_by_me_subq(current_user_id))
             .join(ContentTag, ContentTag.content_id == Content.id)
+            .options(
+                selectinload(Content.author),
+                selectinload(Content.workspace),
+                selectinload(Content.content_tags).selectinload(ContentTag.tag),
+            )
             .where(ContentTag.tag_id == tag_id, Content.deleted_at.is_(None))
             .order_by(Content.created_at.desc())
             .limit(limit)
             .offset(offset)
         )
-        return await self.scalars(stmt)
+        rows = (await self.session.execute(stmt)).all()
+        return [
+            (content, ContentStats(like_count=int(lc), comment_count=int(cc), liked_by_me=bool(lm)))
+            for content, lc, cc, lm in rows
+        ]
 
     async def get_content_tag(self, content_id: UUID, tag_id: UUID) -> ContentTag | None:
         return await self.session.scalar(

--- a/backend/app/repositories/tasks.py
+++ b/backend/app/repositories/tasks.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.models.content import Content
+from app.models.tag import ContentTag
 from app.models.task import Task
 from app.repositories.base import Repository
 from app.repositories.content import (
@@ -29,8 +30,9 @@ class TaskRepository(Repository):
             select(Task, like_count_subq(), comment_count_subq(), liked_by_me_subq(current_user_id))
             .options(
                 selectinload(Task.author),
-                selectinload(Task.event),
-                selectinload(Task.content_tags),
+                selectinload(Task.workspace),
+                selectinload(Task.comments),
+                selectinload(Task.content_tags).selectinload(ContentTag.tag),
             )
             .where(Task.id == task_id, Task.deleted_at.is_(None))
         )
@@ -47,7 +49,9 @@ class TaskRepository(Repository):
             select(Task, like_count_subq(), comment_count_subq(), liked_by_me_subq(current_user_id))
             .options(
                 selectinload(Task.author),
-                selectinload(Task.content_tags),
+                selectinload(Task.workspace),
+                selectinload(Task.comments),
+                selectinload(Task.content_tags).selectinload(ContentTag.tag),
             )
             .where(Task.id == task_id, Task.event_id == event_id, Task.deleted_at.is_(None))
         )
@@ -75,7 +79,46 @@ class TaskRepository(Repository):
     ) -> list[tuple[Task, ContentStats]]:
         stmt = (
             select(Task, like_count_subq(), comment_count_subq(), liked_by_me_subq(current_user_id))
+            .options(
+                selectinload(Task.author),
+                selectinload(Task.workspace),
+                selectinload(Task.content_tags).selectinload(ContentTag.tag),
+            )
             .where(Task.event_id == event_id, Task.deleted_at.is_(None))
+            .order_by(Task.name)
+            .limit(limit)
+            .offset(offset)
+        )
+        rows = (await self.session.execute(stmt)).all()
+        return [
+            (task, ContentStats(like_count=int(lc), comment_count=int(cc), liked_by_me=bool(lm)))
+            for task, lc, cc, lm in rows
+        ]
+
+    async def count_for_workspace(self, workspace_id: UUID) -> int:
+        result = await self.session.scalar(
+            select(func.count())
+            .select_from(Task)
+            .where(Task.workspace_id == workspace_id, Task.deleted_at.is_(None))
+        )
+        return result or 0
+
+    async def list_for_workspace(
+        self,
+        workspace_id: UUID,
+        current_user_id: UUID | None = None,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[tuple[Task, ContentStats]]:
+        stmt = (
+            select(Task, like_count_subq(), comment_count_subq(), liked_by_me_subq(current_user_id))
+            .options(
+                selectinload(Task.author),
+                selectinload(Task.workspace),
+                selectinload(Task.content_tags).selectinload(ContentTag.tag),
+            )
+            .where(Task.workspace_id == workspace_id, Task.deleted_at.is_(None))
             .order_by(Task.name)
             .limit(limit)
             .offset(offset)

--- a/backend/app/repositories/workspaces.py
+++ b/backend/app/repositories/workspaces.py
@@ -9,9 +9,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.models.content import Content
-from app.models.event import Event
-from app.models.program import Program
-from app.models.task import Task
 from app.models.troop import Troop
 from app.models.workspace import Workspace, WorkspaceMembership, WorkspaceRole
 
@@ -67,66 +64,16 @@ class WorkspaceRepository(Repository):
 
     async def delete(self, workspace_id: UUID) -> int:
         now = dt.datetime.now(dt.timezone.utc)
-        # Program/Event/Task use joined-table inheritance: each has its own
-        # table (programs/events/tasks) with a FK to `content`.  deleted_at is
-        # only on `content`, so update(Task/Event/Program) would be a
-        # cross-table SET which PostgreSQL rejects.  Strategy:
-        #   1. Use subclass mappers for SELECT only (JTI joins are fine there).
-        #   2. Cascade via update(Content) keyed by pre-fetched IDs.
 
-        # Pre-fetch event IDs for this workspace
-        event_ids = list(
-            (
-                await self.session.execute(
-                    select(Event.id).where(Event.workspace_id == workspace_id)
-                )
-            ).scalars()
+        # Cascade: soft-delete all content items (programs, events, tasks) in the workspace.
+        # workspace_id is on the content table so one query covers all content types.
+        await self.session.execute(
+            update(Content)
+            .where(Content.workspace_id == workspace_id, Content.deleted_at.is_(None))
+            .values(deleted_at=now)
         )
 
-        # Pre-fetch task IDs for those events
-        task_ids: list = []
-        if event_ids:
-            task_ids = list(
-                (
-                    await self.session.execute(select(Task.id).where(Task.event_id.in_(event_ids)))
-                ).scalars()
-            )
-
-        # Pre-fetch program IDs for this workspace
-        program_ids = list(
-            (
-                await self.session.execute(
-                    select(Program.id).where(Program.workspace_id == workspace_id)
-                )
-            ).scalars()
-        )
-
-        # Cascade: soft-delete tasks
-        if task_ids:
-            await self.session.execute(
-                update(Content)
-                .where(Content.id.in_(task_ids), Content.deleted_at.is_(None))
-                .values(deleted_at=now)
-            )
-
-        # Cascade: soft-delete events
-        if event_ids:
-            await self.session.execute(
-                update(Content)
-                .where(Content.id.in_(event_ids), Content.deleted_at.is_(None))
-                .values(deleted_at=now)
-            )
-
-        # Cascade: soft-delete programs
-        if program_ids:
-            await self.session.execute(
-                update(Content)
-                .where(Content.id.in_(program_ids), Content.deleted_at.is_(None))
-                .values(deleted_at=now)
-            )
-
-        # Cascade: soft-delete troops
-        # (Troop has its own table with deleted_at — no cross-table issue)
+        # Cascade: soft-delete troops (separate table with its own deleted_at)
         await self.session.execute(
             update(Troop)
             .where(Troop.workspace_id == workspace_id, Troop.deleted_at.is_(None))

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.auth import check_workspace_access, get_current_user
 from app.core.db import get_session
 from app.core.pagination import Limit, Offset, add_pagination_headers
-from app.schemas.event import EventCreate, EventOut, EventUpdate
+from app.schemas.event import EventCreate, EventListOut, EventOut, EventUpdate
 from app.schemas.user import UserOut
 from app.schemas.workspace import WorkspaceRole
 from app.services.events import EventService
@@ -25,7 +25,7 @@ DEFAULT_DATE_TO = Query(None)
 # ----- collections -----
 
 
-@router.get("/workspaces/{workspace_id}/events", response_model=list[EventOut])
+@router.get("/workspaces/{workspace_id}/events", response_model=list[EventListOut])
 async def list_workspace_events(
     session: SessionDep,
     workspace_id: UUID,
@@ -36,7 +36,7 @@ async def list_workspace_events(
     date_to: dt.datetime | None = DEFAULT_DATE_TO,
     limit: Limit = 50,
     offset: Offset = 0,
-) -> list[EventOut]:
+) -> list[EventListOut]:
     await check_workspace_access(
         workspace_id, current_user, session, minimum_role=WorkspaceRole.viewer
     )
@@ -62,7 +62,7 @@ async def list_workspace_events(
 
 @router.get(
     "/workspaces/{workspace_id}/programs/{program_id}/events",
-    response_model=list[EventOut],
+    response_model=list[EventListOut],
 )
 async def list_program_events(
     session: SessionDep,
@@ -75,7 +75,7 @@ async def list_program_events(
     date_to: dt.datetime | None = DEFAULT_DATE_TO,
     limit: Limit = 50,
     offset: Offset = 0,
-) -> list[EventOut]:
+) -> list[EventListOut]:
     await check_workspace_access(
         workspace_id, current_user, session, minimum_role=WorkspaceRole.viewer
     )
@@ -118,7 +118,8 @@ async def create_workspace_event(
         workspace_id, current_user, session, minimum_role=WorkspaceRole.editor
     )
     svc = EventService(session)
-    event = await svc.create_under_workspace(workspace_id, body)
+    event_data = body.model_copy(update={"author_id": current_user.id})
+    event = await svc.create_under_workspace(workspace_id, event_data)
     response.headers["Location"] = f"/events/{event.id}"
     return event
 
@@ -147,7 +148,8 @@ async def create_program_event(
         hide_from_non_members=True,
     )
     svc = EventService(session)
-    event = await svc.create_under_program(program_id, body)
+    event_data = body.model_copy(update={"author_id": current_user.id})
+    event = await svc.create_under_program(program_id, event_data)
     response.headers["Location"] = f"/events/{event.id}"
     return event
 

--- a/backend/app/routers/programs.py
+++ b/backend/app/routers/programs.py
@@ -11,7 +11,7 @@ from app.core.auth import check_program_edit_access, check_workspace_access, get
 from app.core.db import get_session
 from app.core.pagination import Limit, Offset, add_pagination_headers
 from app.models.content import ContentType
-from app.schemas.program import ProgramCreate, ProgramOut, ProgramUpdate
+from app.schemas.program import ProgramCreate, ProgramListOut, ProgramOut, ProgramUpdate
 from app.schemas.user import UserOut
 from app.schemas.workspace import WorkspaceRole
 from app.services.programs import ProgramService
@@ -22,7 +22,7 @@ SessionDep = Annotated[AsyncSession, Depends(get_session)]
 # ----- workspace-scoped collection endpoints -----
 
 
-@router.get("/workspaces/{workspace_id}/programs", response_model=list[ProgramOut])
+@router.get("/workspaces/{workspace_id}/programs", response_model=list[ProgramListOut])
 async def list_workspace_programs(
     session: SessionDep,
     request: Request,
@@ -31,7 +31,7 @@ async def list_workspace_programs(
     current_user: UserOut = Depends(get_current_user),
     limit: Limit = 50,
     offset: Offset = 0,
-) -> list[ProgramOut]:
+) -> list[ProgramListOut]:
     svc = ProgramService(session)
     await check_workspace_access(
         workspace_id, current_user, session, minimum_role=WorkspaceRole.viewer
@@ -101,9 +101,12 @@ async def copy_program_to_workspace(
         location=original_program.location,
         count=original_program.count,
         price=original_program.price,
+        prep_time=original_program.prep_time,
+        media=original_program.media,
         author_id=current_user.id,
         content_type=ContentType.program,
         image=original_program.image,
+        tag_names=[t.name for t in original_program.tags],
     )
     program = await svc.create_under_workspace(workspace_id, copied_program)
     response.headers["Location"] = f"/programs/{program.id}"
@@ -144,7 +147,7 @@ async def update_program(
     program = await svc.get(program_id)
     await check_program_edit_access(
         program.workspace_id,
-        program.author_id,
+        program.author.id,
         current_user,
         session,
         hide_from_non_members=True,

--- a/backend/app/routers/tags.py
+++ b/backend/app/routers/tags.py
@@ -11,7 +11,7 @@ from app.core.auth import get_current_user, require_permission
 from app.core.cache import tags_cache
 from app.core.db import get_session
 from app.core.pagination import Limit, Offset, add_pagination_headers
-from app.schemas.content import ContentOut
+from app.schemas.content import ContentListOut
 from app.schemas.tag import (
     ContentTagOut,
     TagCreate,
@@ -75,7 +75,7 @@ async def create_tag(
     session: SessionDep,
     body: TagCreate,
     response: Response,
-    current_user: UserOut = Depends(require_permission(Permissions.admin)),
+    current_user: UserOut = Depends(require_permission(Permissions.member)),
 ) -> TagOut:
     svc = TagService(session)
     tag = await svc.create(body)
@@ -102,7 +102,7 @@ async def update_tag(
     session: SessionDep,
     tag_id: UUID,
     body: TagUpdate,
-    current_user: UserOut = Depends(require_permission(Permissions.admin)),
+    current_user: UserOut = Depends(require_permission(Permissions.member)),
 ) -> TagOut:
     svc = TagService(session)
     updated = await svc.update(tag_id, body)
@@ -114,7 +114,7 @@ async def update_tag(
 async def delete_tag(
     session: SessionDep,
     tag_id: UUID,
-    current_user: UserOut = Depends(require_permission(Permissions.admin)),
+    current_user: UserOut = Depends(require_permission(Permissions.member)),
 ) -> None:
     svc = TagService(session)
     await svc.delete(tag_id)
@@ -148,7 +148,7 @@ async def list_content_tags(
     return items
 
 
-@router.get("/tags/{tag_id}/content", response_model=list[ContentOut])
+@router.get("/tags/{tag_id}/content", response_model=list[ContentListOut])
 async def list_tagged_content(
     session: SessionDep,
     request: Request,
@@ -157,10 +157,10 @@ async def list_tagged_content(
     current_user: UserOut = Depends(get_current_user),
     limit: Limit = 50,
     offset: Offset = 0,
-) -> list[ContentOut]:
+) -> list[ContentListOut]:
     svc = TagService(session)
     total = await svc.count_tagged_content(tag_id)
-    items = await svc.list_tagged_content(tag_id, limit=limit, offset=offset)
+    items = await svc.list_tagged_content(tag_id, current_user.id, limit=limit, offset=offset)
     add_pagination_headers(
         response=response,
         request=request,

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -10,9 +10,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.auth import check_workspace_access, get_current_user
 from app.core.db import get_session
 from app.core.pagination import Limit, Offset, add_pagination_headers
-from app.models.workspace import WorkspaceRole
-from app.schemas.task import TaskCreate, TaskOut, TaskUpdate
+from app.schemas.task import TaskCreate, TaskListOut, TaskOut, TaskUpdate
 from app.schemas.user import UserOut
+from app.schemas.workspace import WorkspaceRole
 from app.services.events import EventService
 from app.services.tasks import TaskService
 
@@ -20,10 +20,69 @@ router = APIRouter(tags=["tasks"])
 SessionDep = Annotated[AsyncSession, Depends(get_session)]
 
 
+# ----- collection under workspace -----
+
+
+@router.get("/workspaces/{workspace_id}/tasks", response_model=list[TaskListOut])
+async def list_workspace_tasks(
+    session: SessionDep,
+    request: Request,
+    response: Response,
+    workspace_id: UUID,
+    current_user: UserOut = Depends(get_current_user),
+    limit: Limit = 50,
+    offset: Offset = 0,
+) -> list[TaskListOut]:
+    svc = TaskService(session)
+    await check_workspace_access(
+        workspace_id,
+        current_user,
+        session,
+        minimum_role=WorkspaceRole.viewer,
+        hide_from_non_members=True,
+    )
+    total = await svc.count_for_workspace(workspace_id)
+    items = await svc.list_for_workspace(workspace_id, current_user.id, limit=limit, offset=offset)
+    add_pagination_headers(
+        response=response,
+        request=request,
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
+    return items
+
+
+@router.post(
+    "/workspaces/{workspace_id}/tasks",
+    response_model=TaskOut,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_workspace_task(
+    session: SessionDep,
+    workspace_id: UUID,
+    body: TaskCreate,
+    response: Response,
+    current_user: UserOut = Depends(get_current_user),
+) -> TaskOut:
+    svc = TaskService(session)
+    await check_workspace_access(
+        workspace_id,
+        current_user,
+        session,
+        minimum_role=WorkspaceRole.editor,
+        hide_from_non_members=True,
+    )
+    task_data = body.model_copy(update={"author_id": current_user.id})
+    task = await svc.create_under_workspace(workspace_id, task_data)
+    response.headers["Location"] = f"/tasks/{task.id}"
+    return task
+
+
 # ----- collection under event -----
 
 
-@router.get("/events/{event_id}/tasks", response_model=list[TaskOut])
+@router.get("/events/{event_id}/tasks", response_model=list[TaskListOut])
 async def list_event_tasks(
     session: SessionDep,
     request: Request,
@@ -32,7 +91,7 @@ async def list_event_tasks(
     current_user: UserOut = Depends(get_current_user),
     limit: Limit = 50,
     offset: Offset = 0,
-) -> list[TaskOut]:
+) -> list[TaskListOut]:
     svc = TaskService(session)
     event_svc = EventService(session)
     event = await event_svc.get(event_id, current_user.id)
@@ -77,7 +136,8 @@ async def create_event_task(
         minimum_role=WorkspaceRole.editor,
         hide_from_non_members=True,
     )
-    task = await svc.create_under_event(event_id, body)
+    task_data = body.model_copy(update={"author_id": current_user.id})
+    task = await svc.create_under_event(event_id, task_data)
     response.headers["Location"] = f"/tasks/{task.id}"
     return task
 
@@ -90,14 +150,12 @@ async def get_task(
     session: SessionDep, task_id: UUID, current_user: UserOut = Depends(get_current_user)
 ) -> TaskOut:
     svc = TaskService(session)
-    event_svc = EventService(session)
     task = await svc.get(task_id, current_user.id)
-    event = await event_svc.get(task.event_id, current_user.id)
     await check_workspace_access(
-        event.workspace_id,
+        task.workspace_id,
         current_user,
         session,
-        minimum_role=WorkspaceRole.editor,
+        minimum_role=WorkspaceRole.viewer,
         hide_from_non_members=True,
     )
     return task
@@ -111,11 +169,9 @@ async def update_task(
     current_user: UserOut = Depends(get_current_user),
 ) -> TaskOut:
     svc = TaskService(session)
-    event_svc = EventService(session)
     task = await svc.get(task_id, current_user.id)
-    event = await event_svc.get(task.event_id, current_user.id)
     await check_workspace_access(
-        event.workspace_id,
+        task.workspace_id,
         current_user,
         session,
         minimum_role=WorkspaceRole.editor,
@@ -129,14 +185,12 @@ async def delete_task(
     session: SessionDep, task_id: UUID, current_user: UserOut = Depends(get_current_user)
 ) -> None:
     svc = TaskService(session)
-    event_svc = EventService(session)
     task = await svc.get(task_id, current_user.id)
-    event = await event_svc.get(task.event_id, current_user.id)
     await check_workspace_access(
-        event.workspace_id,
+        task.workspace_id,
         current_user,
         session,
-        minimum_role=WorkspaceRole.editor,
+        minimum_role=WorkspaceRole.admin,
         hide_from_non_members=True,
     )
     await svc.delete(task_id)

--- a/backend/app/schemas/content.py
+++ b/backend/app/schemas/content.py
@@ -17,6 +17,7 @@ from typing_extensions import Self
 from app.domain.content_constraints import (
     DESC_MAX,
     DURATION_MAX,
+    IMG_MAX,
     INSTRUCTIONS_MAX,
     LOCATION_MAX,
     NAME_MAX,
@@ -24,9 +25,12 @@ from app.domain.content_constraints import (
 )
 from app.models.content import AgeGroup
 from app.repositories.content import ContentStats
+from app.schemas.comment import CommentOut
 from app.schemas.tag import TagOut
-from app.schemas.user import UserOut
+from app.schemas.user import UserOutLimited
 from app.utils import get_current_datetime
+
+from .workspace import WorkspaceNested
 
 NameStr = Annotated[
     str,
@@ -45,12 +49,14 @@ DurationStr = Annotated[
 LocationStr = Annotated[
     str, StringConstraints(min_length=0, max_length=LOCATION_MAX, strip_whitespace=True)
 ]
+ImageStr = Annotated[
+    str, StringConstraints(min_length=0, max_length=IMG_MAX, strip_whitespace=True)
+]
 
 
 class ContentBase(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True)
 
-    name: NameStr
     description: DescStr | None = None
     equipment: list[str] | None = None
     instructions: InstructionsStr | None = None
@@ -60,8 +66,10 @@ class ContentBase(BaseModel):
     count: int | None = None
     price: int | None = None
     prep_time: DurationStr | None = None
+    image: ImageStr | None = None
+    media: dict[str, Any] | None = None
+    tag_names: list[str] | None = None
     author_id: UUID | None = None
-    created_at: dt.datetime = Field(default_factory=get_current_datetime)
 
     @field_validator("count", "price")
     @classmethod
@@ -72,37 +80,37 @@ class ContentBase(BaseModel):
 
 
 class ContentCreate(ContentBase):
-    tag_names: list[str] | None = None
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    name: NameStr
+    created_at: dt.datetime = Field(default_factory=get_current_datetime)
 
 
-class ContentUpdate(BaseModel):
+class ContentUpdate(ContentBase):
     model_config = ConfigDict(str_strip_whitespace=True)
 
     name: NameStr | None = None
+
+
+class ContentListOut(BaseModel):
+    """Content details for list views, without author info or comments."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    name: NameStr
+    author_name: str
+    created_at: dt.datetime
+    workspace_id: UUID
+    workspace: WorkspaceNested
     description: DescStr | None = None
-    equipment: list[str] | None = None
-    instructions: InstructionsStr | None = None
     duration: DurationStr | None = None
     age: list[AgeGroup] | None = None
     location: LocationStr | None = None
     count: int | None = None
     price: int | None = None
     prep_time: DurationStr | None = None
-    tag_names: list[str] | None = None
-
-    @field_validator("count", "price")
-    @classmethod
-    def validate_non_negative_ints(cls, v: int | None, info: ValidationInfo) -> int | None:
-        if v is not None and v < 0:
-            raise ValueError(f"{info.field_name} must be >= 0")
-        return v
-
-
-class ContentOut(ContentBase):
-    model_config = ConfigDict(from_attributes=True)
-
-    id: UUID
-    author: UserOut
+    image: ImageStr | None = None
     tags: list[TagOut] = []
     comment_count: int = 0
     like_count: int = 0
@@ -113,5 +121,15 @@ class ContentOut(ContentBase):
         return cls.model_validate(obj).model_copy(update=vars(stats))
 
 
-UserOut.model_rebuild()
+class ContentOut(ContentListOut):
+    """Full content details, including author info and comments."""
+
+    author: UserOutLimited
+    equipment: list[str] | None = None
+    instructions: InstructionsStr | None = None
+    media: dict[str, Any] | None = None
+    comments: list[CommentOut] = []
+
+
+UserOutLimited.model_rebuild()
 TagOut.model_rebuild()

--- a/backend/app/schemas/event.py
+++ b/backend/app/schemas/event.py
@@ -9,8 +9,8 @@ from pydantic import ConfigDict, Field, field_validator
 from app.models.content import ContentType
 from app.utils import get_current_datetime
 
-from .content import ContentCreate, ContentOut, ContentUpdate
-from .workspace import WorkspaceNested  # Import for nested workspace
+from .content import ContentCreate, ContentListOut, ContentOut, ContentUpdate
+from .task import TaskListOut
 
 
 def _ensure_tzaware(value: dt.datetime, field: str) -> dt.datetime:
@@ -41,7 +41,6 @@ class EventCreate(ContentCreate):
 class EventUpdate(ContentUpdate):
     start_dt: dt.datetime | None = None
     end_dt: dt.datetime | None = None
-    workspace_id: UUID | None = None
     program_id: UUID | None = None
 
     @field_validator("start_dt")
@@ -59,11 +58,18 @@ class EventUpdate(ContentUpdate):
         return _ensure_tzaware(v, "end_dt")
 
 
+class EventListOut(ContentListOut):
+    model_config = ConfigDict(from_attributes=True)
+
+    start_dt: dt.datetime
+    end_dt: dt.datetime | None = None
+    program_id: UUID | None
+
+
 class EventOut(ContentOut):
     model_config = ConfigDict(from_attributes=True)
 
     start_dt: dt.datetime
     end_dt: dt.datetime | None = None
-    workspace_id: UUID
-    workspace: WorkspaceNested
     program_id: UUID | None
+    tasks: list[TaskListOut] = []

--- a/backend/app/schemas/program.py
+++ b/backend/app/schemas/program.py
@@ -1,34 +1,28 @@
 from __future__ import annotations
 
-from typing import Annotated, Literal
-from uuid import UUID
+from typing import Literal
 
-from pydantic import ConfigDict, StringConstraints
+from pydantic import ConfigDict
 
-from app.domain.program_constraints import IMG_MAX
 from app.models.content import ContentType
 
-from .content import ContentCreate, ContentOut, ContentUpdate
-from .workspace import WorkspaceNested
-
-ImageStr = Annotated[
-    str, StringConstraints(min_length=0, max_length=IMG_MAX, strip_whitespace=True)
-]
+from .content import ContentCreate, ContentListOut, ContentOut, ContentUpdate
+from .event import EventListOut
 
 
 class ProgramCreate(ContentCreate):
     content_type: Literal[ContentType.program] = ContentType.program
-    image: ImageStr | None = None
 
 
 class ProgramUpdate(ContentUpdate):
-    workspace_id: UUID | None = None
-    image: ImageStr | None = None
+    pass
+
+
+class ProgramListOut(ContentListOut):
+    model_config = ConfigDict(from_attributes=True)
+    pass
 
 
 class ProgramOut(ContentOut):
     model_config = ConfigDict(from_attributes=True)
-
-    image: ImageStr | None = None
-    workspace_id: UUID
-    workspace: WorkspaceNested
+    events: list[EventListOut] = []

--- a/backend/app/schemas/task.py
+++ b/backend/app/schemas/task.py
@@ -1,99 +1,30 @@
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Literal
 from uuid import UUID
 
-from pydantic import ConfigDict, field_validator, model_validator
+from pydantic import ConfigDict
 
 from app.models.content import ContentType
 
-from .content import ContentCreate, ContentOut, ContentUpdate
+from .content import ContentCreate, ContentListOut, ContentOut, ContentUpdate
 
 
 class TaskCreate(ContentCreate):
     content_type: Literal[ContentType.task] = ContentType.task
 
-    media: dict[str, Any] | None = None
-    estimated_duration: int | None = None
-    participant_min: int | None = None
-    participant_max: int | None = None
-
-    @field_validator("estimated_duration")
-    @classmethod
-    def _non_negative_duration(cls, v: int | None) -> int | None:
-        if v is not None and v < 0:
-            raise ValueError("estimated_duration must be >= 0")
-        return v
-
-    @field_validator("participant_min")
-    @classmethod
-    def _non_negative_min(cls, v: int | None) -> int | None:
-        if v is not None and v < 0:
-            raise ValueError("participant_min must be >= 0")
-        return v
-
-    @field_validator("participant_max")
-    @classmethod
-    def _positive_max(cls, v: int | None) -> int | None:
-        if v is not None and v <= 0:
-            raise ValueError("participant_max must be > 0")
-        return v
-
-    @model_validator(mode="after")
-    def _cross_validate_participants(self) -> TaskCreate:
-        min_v = self.participant_min
-        max_v = self.participant_max
-        if max_v is not None and min_v is not None and max_v < min_v:
-            raise ValueError("participant_max must be >= participant_min")
-        return self
-
 
 class TaskUpdate(ContentUpdate):
     event_id: UUID | None = None
-    media: dict[str, Any] | None = None
-    estimated_duration: int | None = None
-    participant_min: int | None = None
-    participant_max: int | None = None
 
-    @field_validator("estimated_duration")
-    @classmethod
-    def _non_negative_duration(cls, v: int | None) -> int | None:
-        if v is not None and v < 0:
-            raise ValueError("estimated_duration must be >= 0")
-        return v
 
-    @field_validator("participant_min")
-    @classmethod
-    def _validate_participant_min(cls, v: int | None) -> int | None:
-        if v is not None and v < 0:
-            raise ValueError("participant_min must be >= 0")
-        return v
+class TaskListOut(ContentListOut):
+    model_config = ConfigDict(from_attributes=True)
 
-    @field_validator("participant_max")
-    @classmethod
-    def _non_negative_max(cls, v: int | None) -> int | None:
-        if v is not None and v < 0:
-            raise ValueError("participant_max must be >= 0")
-        return v
-
-    @model_validator(mode="after")
-    def _cross_validate_participants(self) -> TaskUpdate:
-        min_v = self.participant_min
-        max_v = self.participant_max
-        if max_v is not None and min_v is not None:
-            if max_v < min_v:
-                raise ValueError("participant_max must be >= participant_min")
-            if max_v == 0 and min_v == 0:
-                raise ValueError("participant_max must be > 0 if participant_min is 0")
-        return self
+    event_id: UUID | None = None
 
 
 class TaskOut(ContentOut):
     model_config = ConfigDict(from_attributes=True)
 
-    id: UUID
-    event_id: UUID
-    media: dict[str, Any] | None = None
-    estimated_duration: int | None = None
-    participant_min: int | None = None
-    participant_max: int | None = None
+    event_id: UUID | None = None

--- a/backend/app/services/events.py
+++ b/backend/app/services/events.py
@@ -9,7 +9,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.event import Event
 from app.repositories.events import EventRepository
 from app.repositories.programs import ProgramRepository
-from app.schemas.event import EventCreate, EventOut, EventUpdate
+from app.repositories.tags import TagRepository
+from app.schemas.event import EventCreate, EventListOut, EventOut, EventUpdate
 
 
 class EventService:
@@ -39,7 +40,7 @@ class EventService:
         date_to: dt.datetime | None = None,
         limit: int = 50,
         offset: int = 0,
-    ) -> list[EventOut]:
+    ) -> list[EventListOut]:
         rows = await self.repo.list_for_workspace(
             workspace_id,
             current_user_id,
@@ -48,7 +49,7 @@ class EventService:
             limit=limit,
             offset=offset,
         )
-        return [EventOut.from_row(event, stats) for event, stats in rows]
+        return [EventListOut.from_row(event, stats) for event, stats in rows]
 
     async def count_events_for_program(
         self,
@@ -72,7 +73,7 @@ class EventService:
         date_to: dt.datetime | None = None,
         limit: int = 50,
         offset: int = 0,
-    ) -> list[EventOut]:
+    ) -> list[EventListOut]:
         rows = await self.repo.list_for_program(
             workspace_id,
             program_id,
@@ -82,13 +83,25 @@ class EventService:
             limit=limit,
             offset=offset,
         )
-        return [EventOut.from_row(event, stats) for event, stats in rows]
+        return [EventListOut.from_row(event, stats) for event, stats in rows]
 
     # ----- creation under workspace/program -----
 
     async def create_under_workspace(self, workspace_id: UUID, data: EventCreate) -> EventOut:
-        event = Event(workspace_id=workspace_id, program_id=None, **data.model_dump())
+        tag_names = data.tag_names or []
+        event = Event(
+            workspace_id=workspace_id, program_id=None, **data.model_dump(exclude={"tag_names"})
+        )
         await self.repo.create(event)
+        await self.session.flush()
+        if tag_names:
+            tag_repo = TagRepository(self.session)
+            not_found = await tag_repo.add_content_tags_by_names(event.id, tag_names)
+            if not_found:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=f"Unknown tags: {not_found}",
+                )
         await self.session.commit()
         fetched = await self.repo.get(event.id)
         if not fetched:
@@ -104,12 +117,22 @@ class EventService:
         if not prog_row:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Program not found")
         prog, _ = prog_row
+        tag_names = data.tag_names or []
         event = Event(
             workspace_id=prog.workspace_id,
             program_id=prog.id,
-            **data.model_dump(),
+            **data.model_dump(exclude={"tag_names"}),
         )
         await self.repo.create(event)
+        await self.session.flush()
+        if tag_names:
+            tag_repo = TagRepository(self.session)
+            not_found = await tag_repo.add_content_tags_by_names(event.id, tag_names)
+            if not_found:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=f"Unknown tags: {not_found}",
+                )
         await self.session.commit()
         fetched = await self.repo.get(event.id)
         if not fetched:
@@ -149,24 +172,33 @@ class EventService:
         if not row:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
         event, _ = row
-        if data.program_id is not None:
-            prog_row = await self.program_repo.get(data.program_id)
-            if not prog_row:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND, detail="Program not found"
-                )
-            prog, _ = prog_row
-            if prog.workspace_id != event.workspace_id:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Program does not belong to the same workspace as the event",
-                )
-            event.program_id = prog.id
-        elif data.program_id is None:
-            event.program_id = None
-        patch = data.model_dump(exclude_unset=True)
+        if "program_id" in data.model_fields_set:
+            if data.program_id is not None:
+                prog_row = await self.program_repo.get(data.program_id)
+                if not prog_row:
+                    raise HTTPException(
+                        status_code=status.HTTP_404_NOT_FOUND, detail="Program not found"
+                    )
+                prog, _ = prog_row
+                if prog.workspace_id != event.workspace_id:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="Program does not belong to the same workspace as the event",
+                    )
+                event.program_id = prog.id
+            else:
+                event.program_id = None
+        patch = data.model_dump(exclude_unset=True, exclude={"program_id", "tag_names"})
         for k, v in patch.items():
             setattr(event, k, v)
+        if "tag_names" in data.model_fields_set:
+            tag_repo = TagRepository(self.session)
+            not_found = await tag_repo.set_content_tags_by_names(event_id, data.tag_names or [])
+            if not_found:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=f"Unknown tags: {not_found}",
+                )
         await self.session.commit()
         updated = await self.repo.get(event_id, current_user_id)
         if not updated:

--- a/backend/app/services/programs.py
+++ b/backend/app/services/programs.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.program import Program
 from app.repositories.programs import ProgramRepository
 from app.repositories.tags import TagRepository
-from app.schemas.program import ProgramCreate, ProgramOut, ProgramUpdate
+from app.schemas.program import ProgramCreate, ProgramListOut, ProgramOut, ProgramUpdate
 
 logger = logging.getLogger(__name__)
 
@@ -30,11 +30,11 @@ class ProgramService:
         *,
         limit: int = 50,
         offset: int = 0,
-    ) -> list[ProgramOut]:
+    ) -> list[ProgramListOut]:
         rows = await self.repo.list_by_workspace(
             workspace_id, current_user_id, limit=limit, offset=offset
         )
-        return [ProgramOut.from_row(prog, stats) for prog, stats in rows]
+        return [ProgramListOut.from_row(prog, stats) for prog, stats in rows]
 
     async def get_in_workspace(
         self, program_id: UUID, workspace_id: UUID, current_user_id: UUID | None = None

--- a/backend/app/services/tags.py
+++ b/backend/app/services/tags.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.tag import Tag
 from app.repositories.tags import TagRepository
-from app.schemas.content import ContentOut
+from app.schemas.content import ContentListOut
 from app.schemas.tag import (
     ContentTagOut,
     TagCreate,
@@ -91,10 +91,10 @@ class TagService:
         return await self.repo.count_tagged_content(tag_id)
 
     async def list_tagged_content(
-        self, tag_id: UUID, *, limit: int = 50, offset: int = 0
-    ) -> list[ContentOut]:  # type: ignore[valid-type]
-        rows = await self.repo.list_tagged_content(tag_id, limit=limit, offset=offset)
-        return [ContentOut.model_validate(r) for r in rows]
+        self, tag_id: UUID, current_user_id: UUID | None = None, *, limit: int = 50, offset: int = 0
+    ) -> list[ContentListOut]:  # type: ignore[valid-type]
+        rows = await self.repo.list_tagged_content(tag_id, current_user_id, limit=limit, offset=offset)
+        return [ContentListOut.from_row(r, stats) for r, stats in rows]  # type: ignore[attr-defined]
 
     async def add_content_tag(self, content_id: UUID, tag_id: UUID) -> tuple[bool, ContentTagOut]:
         try:

--- a/backend/app/services/tasks.py
+++ b/backend/app/services/tasks.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 from uuid import UUID
 
 from fastapi import HTTPException, status
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.content import Content
 from app.models.task import Task
+from app.repositories.tags import TagRepository
 from app.repositories.tasks import TaskRepository
-from app.schemas.task import TaskCreate, TaskOut, TaskUpdate
+from app.schemas.task import TaskCreate, TaskListOut, TaskOut, TaskUpdate
 
 
 class TaskService:
@@ -25,13 +28,71 @@ class TaskService:
         *,
         limit: int = 50,
         offset: int = 0,
-    ) -> list[TaskOut]:
+    ) -> list[TaskListOut]:
         rows = await self.repo.list_for_event(event_id, current_user_id, limit=limit, offset=offset)
-        return [TaskOut.from_row(task, stats) for task, stats in rows]
+        return [TaskListOut.from_row(task, stats) for task, stats in rows]
+
+    async def count_for_workspace(self, workspace_id: UUID) -> int:
+        return await self.repo.count_for_workspace(workspace_id)
+
+    async def list_for_workspace(
+        self,
+        workspace_id: UUID,
+        current_user_id: UUID | None = None,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[TaskListOut]:
+        rows = await self.repo.list_for_workspace(
+            workspace_id, current_user_id, limit=limit, offset=offset
+        )
+        return [TaskListOut.from_row(task, stats) for task, stats in rows]
 
     async def create_under_event(self, event_id: UUID, data: TaskCreate) -> TaskOut:
-        task = Task(event_id=event_id, **data.model_dump())
+        workspace_id = await self.session.scalar(
+            select(Content.workspace_id).where(Content.id == event_id, Content.deleted_at.is_(None))
+        )
+        if workspace_id is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
+        tag_names = data.tag_names or []
+        task = Task(
+            event_id=event_id, workspace_id=workspace_id, **data.model_dump(exclude={"tag_names"})
+        )
         await self.repo.create(task)
+        await self.session.flush()
+        if tag_names:
+            tag_repo = TagRepository(self.session)
+            not_found = await tag_repo.add_content_tags_by_names(task.id, tag_names)
+            if not_found:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=f"Unknown tags: {not_found}",
+                )
+        await self.session.commit()
+        fetched = await self.repo.get(task.id)
+        if not fetched:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to retrieve created task",
+            )
+        t, stats = fetched
+        return TaskOut.from_row(t, stats)
+
+    async def create_under_workspace(self, workspace_id: UUID, data: TaskCreate) -> TaskOut:
+        tag_names = data.tag_names or []
+        task = Task(
+            workspace_id=workspace_id, event_id=None, **data.model_dump(exclude={"tag_names"})
+        )
+        await self.repo.create(task)
+        await self.session.flush()
+        if tag_names:
+            tag_repo = TagRepository(self.session)
+            not_found = await tag_repo.add_content_tags_by_names(task.id, tag_names)
+            if not_found:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=f"Unknown tags: {not_found}",
+                )
         await self.session.commit()
         fetched = await self.repo.get(task.id)
         if not fetched:
@@ -65,9 +126,31 @@ class TaskService:
         if not row:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found")
         task, _ = row
-        patch = data.model_dump(exclude_unset=True)
+        patch = data.model_dump(exclude_unset=True, exclude={"tag_names"})
+        if "event_id" in patch and patch["event_id"] is not None:
+            event_workspace_id = await self.session.scalar(
+                select(Content.workspace_id).where(
+                    Content.id == patch["event_id"],
+                    Content.deleted_at.is_(None),
+                )
+            )
+            if event_workspace_id is None:
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
+            if event_workspace_id != task.workspace_id:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Event does not belong to the same workspace as the task",
+                )
         for k, v in patch.items():
             setattr(task, k, v)
+        if "tag_names" in data.model_fields_set:
+            tag_repo = TagRepository(self.session)
+            not_found = await tag_repo.set_content_tags_by_names(task_id, data.tag_names or [])
+            if not_found:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=f"Unknown tags: {not_found}",
+                )
         await self.session.commit()
         updated = await self.repo.get(task_id, current_user_id)
         if not updated:

--- a/backend/tests/test_models_integration.py
+++ b/backend/tests/test_models_integration.py
@@ -74,6 +74,7 @@ async def test_user_workspace_program_event_task_flow(db):
         description=None,
         created_at=get_current_datetime(),
         author_id=user.id,
+        workspace_id=workspace.id,
         event_id=event.id,
         content_type=m.ContentType.task,
     )

--- a/backend/tests/test_schemas.py
+++ b/backend/tests/test_schemas.py
@@ -44,29 +44,3 @@ def test_event_time_is_tz_aware():
             content_type=m.ContentType.event,
             start_dt=dt.datetime(2025, 1, 1, 10, 0),  # naive
         )
-
-
-def test_task_participants_rules():
-    # max < min -> invalid
-    with pytest.raises(ValidationError):
-        s.TaskCreate(
-            content_type=m.ContentType.task,
-            name="Knot tying",
-            description=None,
-            created_at=get_current_datetime(),
-            author_id=uuid4(),
-            participant_min=5,
-            participant_max=4,
-        )
-
-    # both zero -> invalid
-    with pytest.raises(ValidationError):
-        s.TaskCreate(
-            content_type=m.ContentType.task,
-            name="Game",
-            description=None,
-            created_at=get_current_datetime(),
-            author_id=uuid4(),
-            participant_min=0,
-            participant_max=0,
-        )

--- a/backend/tests/test_soft_delete.py
+++ b/backend/tests/test_soft_delete.py
@@ -37,6 +37,7 @@ def _prog(workspace_id=None):
         workspace_id=wid,
         name="Test Program",
         author_id=uuid4(),
+        author_name="Author",
         created_at=dt.datetime.now(dt.timezone.utc),
         author=UserOut(id=uuid4(), name="Author", email="a@b.com", auth0_id="auth0|x"),
         workspace=WorkspaceNested(id=wid, name="WS"),
@@ -328,6 +329,7 @@ async def test_workspace_soft_delete_cascade(db):
         name="Cascade Task",
         created_at=get_current_datetime(),
         author_id=user.id,
+        workspace_id=ws.id,
         event_id=event.id,
         content_type=m.ContentType.task,
     )
@@ -373,7 +375,7 @@ async def test_workspace_soft_delete_cascade(db):
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_program_soft_delete_cascade(db):
-    """Soft-deleting a program cascades deleted_at to its Events and Tasks."""
+    """Soft-deleting a program orphans its Events; tasks stay attached to their events."""
     from app.repositories.programs import ProgramRepository
 
     user = m.User(name="Prog Casc", auth0_id="auth0|pc1", email="pc@test.com")
@@ -415,6 +417,7 @@ async def test_program_soft_delete_cascade(db):
         name="Prog Casc Task",
         created_at=get_current_datetime(),
         author_id=user.id,
+        workspace_id=ws.id,
         event_id=event.id,
         content_type=m.ContentType.task,
     )
@@ -430,15 +433,21 @@ async def test_program_soft_delete_cascade(db):
 
     assert rows_affected == 1
 
-    # All three rows still exist but are soft-deleted
-    for model_cls, entity_id in [
-        (m.Program, prog_id),
-        (m.Event, event_id),
-        (m.Task, task_id),
-    ]:
-        raw = await db.scalar(select(model_cls).where(model_cls.id == entity_id))
-        assert raw is not None, f"{model_cls.__name__} row must not be hard-deleted"
-        assert raw.deleted_at is not None, f"{model_cls.__name__}.deleted_at must be set"
+    # Program is soft-deleted
+    raw_prog = await db.scalar(select(m.Program).where(m.Program.id == prog_id))
+    assert raw_prog is not None and raw_prog.deleted_at is not None
+
+    # Event is orphaned (program_id=None), not soft-deleted
+    raw_event = await db.scalar(select(m.Event).where(m.Event.id == event_id))
+    assert raw_event is not None, "Event row must not be hard-deleted"
+    assert raw_event.program_id is None, "Event must be orphaned (program_id=None)"
+    assert raw_event.deleted_at is None, "Orphaned event must not be soft-deleted"
+
+    # Task remains attached to its event, not affected
+    raw_task = await db.scalar(select(m.Task).where(m.Task.id == task_id))
+    assert raw_task is not None, "Task row must not be hard-deleted"
+    assert raw_task.event_id == event_id, "Task must remain attached to its event"
+    assert raw_task.deleted_at is None, "Task must not be soft-deleted"
 
 
 @pytest.mark.integration
@@ -475,6 +484,7 @@ async def test_event_soft_delete_cascade(db):
         name="Ev Casc Task",
         created_at=get_current_datetime(),
         author_id=user.id,
+        workspace_id=ws.id,
         event_id=event.id,
         content_type=m.ContentType.task,
     )
@@ -492,8 +502,11 @@ async def test_event_soft_delete_cascade(db):
     raw_event = await db.scalar(select(m.Event).where(m.Event.id == event_id))
     assert raw_event is not None and raw_event.deleted_at is not None
 
+    # Task is orphaned (event_id=None), not soft-deleted
     raw_task = await db.scalar(select(m.Task).where(m.Task.id == task_id))
-    assert raw_task is not None and raw_task.deleted_at is not None
+    assert raw_task is not None, "Task row must not be hard-deleted"
+    assert raw_task.event_id is None, "Task must be orphaned (event_id=None)"
+    assert raw_task.deleted_at is None, "Orphaned task must not be soft-deleted"
 
 
 @pytest.mark.integration

--- a/backend/tests/test_workspace_content.py
+++ b/backend/tests/test_workspace_content.py
@@ -20,6 +20,7 @@ def _make_program(workspace_id):
         workspace_id=workspace_id,
         name="Test Program",
         author_id=uuid4(),
+        author_name="Test User",
         created_at=datetime.now(),
         author=UserOut(
             id=uuid4(), name="Test User", email="test_email@gmail.com", auth0_id="auth0|123"

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,26 +1,34 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  images: {
-    remotePatterns: [
-      {
-        protocol: "https",
-        hostname: "lh3.googleusercontent.com",
-      },
-      {
-        protocol: "https",
-        hostname: "images.unsplash.com",
-      },
-      {
-        protocol: "https",
-        hostname: "cdn.example.com",
-      },
-      {
-        protocol: "https",
-        hostname: "avatars.githubusercontent.com",
-      },
-    ],
-  },
+    images: {
+        remotePatterns: [
+            {
+                protocol: "https",
+                hostname: "lh3.googleusercontent.com",
+            },
+            {
+                protocol: "https",
+                hostname: "images.unsplash.com",
+            },
+            {
+                protocol: "https",
+                hostname: "cdn.example.com",
+            },
+            {
+                protocol: "https",
+                hostname: "avatars.githubusercontent.com",
+            },
+            {
+                protocol: "https",
+                hostname: "images.aha.is",
+            },
+            {
+                protocol: "https",
+                hostname: "shedknives.com",
+            },
+        ],
+    },
 };
 
 export default nextConfig;


### PR DESCRIPTION
- Move workspace_id, image, and media fields to the Content base model so all content subtypes share a single workspace foreign key
- Delete event_constraints.py and program_constraints.py; consolidate into content_constraints.py
- Make task.event_id nullable with SET NULL on event delete so tasks are orphaned (not deleted) when their event is removed
- Fix shallow selectinload on Program.events and Event.tasks: chain sub-options so nested author/workspace/content_tags are loaded, preventing MissingGreenlet in async context
- Remove unused selectinload(Event.program) and selectinload(Task.event) from get() methods (EventOut/TaskOut only expose the FK column)
- Fix GET /tags/{tag_id}/content: add ContentStats subqueries and selectinload(Content.workspace); downgrade response to ContentListOut
- Add three Alembic migrations for the schema changes