### PR TITLE
feat: add Discord notifications to CI workflows

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,5 +1,4 @@
 name: Backend CI
-
 on:
   push:
     paths:
@@ -47,6 +46,14 @@ jobs:
           DB_PORT: "5432"
           AUTH0_DOMAIN: ci.auth0.com
           AUTH0_AUDIENCE: ci
+      - name: Notify Discord
+        if: always()
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          status: ${{ job.status }}
+          title: "Lint & Type Check — ${{ github.repository }}"
+          description: "Branch: `${{ github.ref_name }}` | Commit: `${{ github.sha }}`"
 
   test:
     name: Unit Tests
@@ -73,3 +80,12 @@ jobs:
           DB_PORT: "5432"
           AUTH0_DOMAIN: ci.auth0.com
           AUTH0_AUDIENCE: ci
+
+      - name: Notify Discord
+        if: always()
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          status: ${{ job.status }}
+          title: "Unit Tests — ${{ github.repository }}"
+          description: "Branch: `${{ github.ref_name }}` | Commit: `${{ github.sha }}`"

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,5 +1,4 @@
 name: Frontend CI
-
 on:
   push:
     paths:
@@ -45,3 +44,12 @@ jobs:
           AUTH0_ISSUER_BASE_URL: https://placeholder.auth0.com
           AUTH0_CLIENT_ID: ci_client_id
           AUTH0_CLIENT_SECRET: ci_client_secret
+
+      - name: Notify Discord
+        if: always()
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          status: ${{ job.status }}
+          title: "Lint & Build — ${{ github.repository }}"
+          description: "Branch: `${{ github.ref_name }}` | Commit: `${{ github.sha }}`"


### PR DESCRIPTION
Add sarisia/actions-status-discord step to backend and frontend CI jobs so each job posts its status to Discord on completion.