### PR TITLE
feat: add workspace role management endpoint and enforce single owner

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,36 +1,47 @@
 ENV = "Production"
-LOGGER_LEVEL = "INFO"
 
-# Production database configuration
+# Database configuration
 DB_NAME = "db_name"
 DB_PORT = "5432"
 DB_HOST = "localhost"
 DB_USER = "your_username"
 DB_PASSWORD = "your_password"
 
-# Test database configuration
-TEST_DB_NAME = "test_db_name"
-TEST_DB_PORT = "5432"
-TEST_DB_HOST = "localhost"
-TEST_DB_USER = "your_username"
-TEST_DB_PASSWORD = "your_password"
-
-# Seed: comma-separated list of emails that are always promoted to admin on seed run
-ADMIN_EMAILS = "admin@example.com,another@example.com"
-
-# Seed output directory — where seed.py writes seed_output.json and config.py reads it.
-# In Docker, this is set to a shared named volume path via docker-compose.yml.
-# Leave unset for local dev (defaults to the backend root directory).
-# SEED_OUTPUT_DIR = ""
-
-# CORS configuration
-CORS_ORIGINS = '["http://localhost:3000", "https://slodi.is"]'
-
 # Auth0 configuration
 AUTH0_DOMAIN = "your-tenant.eu.auth0.com"
 AUTH0_AUDIENCE = "https://api.slodi.is"
 AUTH0_ALGORITHMS = '["RS256"]'
+# AUTH0_DEBUG = false
 
-# Resend (email) configuration
+# CORS configuration
+CORS_ORIGINS = '["http://localhost:3000", "https://slodi.is"]'
+
+# Logging
+LOGGER_LEVEL = "INFO"
+# LOGGER_FILE = ""
+
+# Cache (default: in-process memory; set to "redis" for multi-worker deployments)
+CACHE_BACKEND = "memory"
+# REDIS_HOST = "localhost"
+# REDIS_PORT = 6379
+# CACHE_USER_TTL_SECONDS = 300
+# CACHE_MEMBERSHIP_TTL_SECONDS = 120
+# CACHE_TAGS_TTL_SECONDS = 600
+# RATE_LIMIT_MAX_WINDOW_SECONDS = 3600
+
+# Resend (email)
 RESEND_API_KEY = "re_your_api_key"
-RESEND_FROM_EMAIL = "Slóði <noreply@slodi.is>"
+# RESEND_FROM_EMAIL = "Slóði <noreply@slodi.is>"
+
+# Seed: comma-separated list of emails promoted to admin on `make seed`
+ADMIN_EMAILS = "admin@example.com,another@example.com"
+
+# Seed output directory — where seed.py writes seed_output.json.
+# In Docker, set to a shared named volume path via docker-compose.yml.
+# Leave unset for local dev (defaults to the backend root directory).
+# SEED_OUTPUT_DIR = ""
+
+# ID of the workspace all new users are auto-joined to as viewers on first login.
+# Resolved automatically from seed_output.json (written by `make seed`).
+# Override manually if needed — takes priority over seed_output.json.
+# DEFAULT_WORKSPACE_ID = ""

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -9,13 +9,9 @@ This module provides:
 """
 
 import asyncio
-import contextlib
-import json
 import logging
-import os
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 from threading import Lock
 from uuid import UUID
 
@@ -30,6 +26,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.cache import CACHE_MISS, membership_cache, user_cache
 from app.core.config import settings
 from app.core.db import get_session
+from app.core.seed import get_default_workspace_id
 from app.domain.enums import GroupRole, Permissions, WorkspaceRole
 from app.schemas.user import UserCreate, UserOut
 from app.services.groups import GroupService
@@ -281,20 +278,8 @@ def verify_auth0_token(token: str) -> TokenPayload:
 # ---------------------------------------------------------------------------
 
 
-_SEED_OUTPUT = Path(__file__).parent.parent.parent / "seed_output.json"
-
-
-def _get_default_workspace_id() -> UUID | None:
-    ws_id = os.getenv("DEFAULT_WORKSPACE_ID")
-    if not ws_id and _SEED_OUTPUT.exists():
-        with contextlib.suppress(Exception):
-            ws_id = json.loads(_SEED_OUTPUT.read_text()).get("dagskrarbankinn_workspace_id")
-    if ws_id:
-        try:
-            return UUID(ws_id)
-        except ValueError:
-            pass
-    return None
+# Resolved once at startup — this is a deployment-time constant
+_DEFAULT_WORKSPACE_ID: UUID | None = get_default_workspace_id()
 
 
 async def get_current_user(
@@ -385,20 +370,17 @@ async def get_current_user(
     user_data = UserCreate(auth0_id=auth0_id, email=email, name=name)
     user = await user_service.create(user_data)
 
-    if not user:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to create user",
-        )
-
-    default_ws_id = _get_default_workspace_id()
-    if default_ws_id:
+    if _DEFAULT_WORKSPACE_ID:
         try:
             ws_service = WorkspaceService(session)
-            await ws_service.add_member(default_ws_id, user.id, WorkspaceRole.viewer)
+            await ws_service.set_member_role(_DEFAULT_WORKSPACE_ID, user.id, WorkspaceRole.viewer)
+            logger.info("Added new user %s to default workspace %s", user.id, _DEFAULT_WORKSPACE_ID)
         except Exception:
             logger.warning(
-                "Failed to add new user %s to default workspace %s", user.id, default_ws_id
+                "Failed to add new user %s to default workspace %s",
+                user.id,
+                _DEFAULT_WORKSPACE_ID,
+                exc_info=True,
             )
 
     await user_cache.set(auth0_id, user)

--- a/backend/app/core/seed.py
+++ b/backend/app/core/seed.py
@@ -1,0 +1,60 @@
+"""Utilities for reading the seed_output.json produced by seed.py.
+
+Both auth.py (startup resolution) and routers/config.py (public endpoint)
+need to read this file — this module is the single source of truth for that
+logic and the key names used in the JSON.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+from pathlib import Path
+from uuid import UUID
+
+logger = logging.getLogger(__name__)
+
+# JSON key written by seed.py for the default workspace ID
+SEED_KEY_DEFAULT_WS = "dagskrarbankinn_workspace_id"
+
+_default_seed_dir = str(Path(__file__).parent.parent.parent)
+_SEED_OUTPUT = Path(os.getenv("SEED_OUTPUT_DIR", _default_seed_dir)) / "seed_output.json"
+
+
+def read_seed_output() -> dict:
+    """Return the parsed contents of seed_output.json, or {} on any failure.
+
+    Prefers the DEFAULT_WORKSPACE_ID env var (fast path) so Docker deployments
+    that inject the value at runtime never need the file on disk.
+    """
+    ws_id = os.getenv("DEFAULT_WORKSPACE_ID")
+    if ws_id:
+        return {SEED_KEY_DEFAULT_WS: ws_id}
+    if _SEED_OUTPUT.exists():
+        try:
+            return json.loads(_SEED_OUTPUT.read_text())
+        except Exception:
+            logger.warning("Failed to read seed_output.json at %s", _SEED_OUTPUT, exc_info=True)
+    return {}
+
+
+def get_default_workspace_id() -> UUID | None:
+    """Return the default workspace UUID, or None if not configured.
+
+    Resolution order:
+    1. DEFAULT_WORKSPACE_ID environment variable (takes priority)
+    2. dagskrarbankinn_workspace_id key in seed_output.json
+
+    Resolved once at startup — treat the return value as a deployment-time constant.
+    """
+    ws_id: str | None = None
+    with contextlib.suppress(Exception):
+        ws_id = read_seed_output().get(SEED_KEY_DEFAULT_WS)
+    if ws_id:
+        try:
+            return UUID(ws_id)
+        except ValueError:
+            logger.warning("DEFAULT_WORKSPACE_ID '%s' is not a valid UUID — ignoring", ws_id)
+    return None

--- a/backend/app/repositories/workspaces.py
+++ b/backend/app/repositories/workspaces.py
@@ -91,12 +91,13 @@ class WorkspaceRepository(Repository):
         assert isinstance(res, CursorResult)
         return res.rowcount or 0
 
-    async def add_member(
-        self, workspace_id: UUID, user_id: UUID, role: WorkspaceRole
-    ) -> WorkspaceMembership:
-        membership = WorkspaceMembership(workspace_id=workspace_id, user_id=user_id, role=role)
-        await self.add(membership)
-        return membership
+    async def get_workspace_owner(self, workspace_id: UUID) -> WorkspaceMembership | None:
+        stmt = select(WorkspaceMembership).where(
+            WorkspaceMembership.workspace_id == workspace_id,
+            WorkspaceMembership.role == WorkspaceRole.owner,
+        )
+        res = await self.session.execute(stmt)
+        return res.scalars().first()
 
     async def get_user_membership(
         self, workspace_id: UUID, user_id: UUID
@@ -106,3 +107,14 @@ class WorkspaceRepository(Repository):
         )
         res = await self.session.execute(stmt)
         return res.scalars().first()
+
+    async def set_member_role(
+        self, workspace_id: UUID, user_id: UUID, role: WorkspaceRole
+    ) -> WorkspaceMembership:
+        membership = await self.get_user_membership(workspace_id, user_id)
+        if membership:
+            membership.role = role
+        else:
+            membership = WorkspaceMembership(workspace_id=workspace_id, user_id=user_id, role=role)
+            await self.add(membership)
+        return membership

--- a/backend/app/routers/config.py
+++ b/backend/app/routers/config.py
@@ -5,42 +5,26 @@ No authentication required. Only exposes non-sensitive values.
 
 from __future__ import annotations
 
-import json
-import os
-from pathlib import Path
+import logging
 
 from fastapi import APIRouter
 from pydantic import BaseModel
 
-router = APIRouter(tags=["config"])
+from app.core.seed import SEED_KEY_DEFAULT_WS, read_seed_output
 
-# Seed output written by seed.py — location controlled by SEED_OUTPUT_DIR env var
-_default_seed_dir = str(Path(__file__).parent.parent.parent)
-_SEED_OUTPUT = Path(os.getenv("SEED_OUTPUT_DIR", _default_seed_dir)) / "seed_output.json"
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["config"])
 
 
 class PublicConfig(BaseModel):
     default_workspace_id: str | None = None
 
 
-def _read_seed_output() -> dict:
-    # Prefer the env var set by the entrypoint (fast path)
-    ws_id = os.getenv("DEFAULT_WORKSPACE_ID")
-    if ws_id:
-        return {"dagskrarbankinn_workspace_id": ws_id}
-    # Fall back to reading the file directly
-    if _SEED_OUTPUT.exists():
-        try:
-            return json.loads(_SEED_OUTPUT.read_text())
-        except Exception:
-            pass
-    return {}
-
-
 @router.get("/config/public", response_model=PublicConfig)
 async def get_public_config() -> PublicConfig:
     """Return public runtime configuration values for the frontend."""
-    data = _read_seed_output()
+    data = read_seed_output()
     return PublicConfig(
-        default_workspace_id=data.get("dagskrarbankinn_workspace_id"),
+        default_workspace_id=data.get(SEED_KEY_DEFAULT_WS),
     )

--- a/backend/app/routers/workspaces.py
+++ b/backend/app/routers/workspaces.py
@@ -16,6 +16,7 @@ from app.schemas.user import UserOut
 from app.schemas.workspace import (
     WorkspaceCreate,
     WorkspaceMembershipOut,
+    WorkspaceMembershipUpdate,
     WorkspaceOut,
     WorkspaceUpdate,
 )
@@ -160,6 +161,28 @@ async def update_workspace(
     )
     svc = WorkspaceService(session)
     return await svc.update(workspace_id, body)
+
+
+@router.put(
+    "/workspaces/{workspace_id}/members/{user_id}/role",
+    response_model=WorkspaceMembershipOut,
+)
+async def set_member_role(
+    session: SessionDep,
+    workspace_id: UUID,
+    user_id: UUID,
+    body: WorkspaceMembershipUpdate,
+    current_user: UserOut = Depends(get_current_user),
+) -> WorkspaceMembershipOut:
+    await check_workspace_access(
+        workspace_id, current_user, session, minimum_role=WorkspaceRole.admin
+    )
+    svc = WorkspaceService(session)
+    result, displaced_owner_id = await svc.set_member_role(workspace_id, user_id, body.role)
+    await membership_cache.invalidate(user_id, workspace_id)
+    if displaced_owner_id:
+        await membership_cache.invalidate(displaced_owner_id, workspace_id)
+    return result
 
 
 @router.delete("/workspaces/{workspace_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/schemas/workspace.py
+++ b/backend/app/schemas/workspace.py
@@ -86,7 +86,7 @@ class WorkspaceMembershipCreate(WorkspaceMembershipBase):
 
 
 class WorkspaceMembershipUpdate(BaseModel):
-    role: WorkspaceRole | None = None
+    role: WorkspaceRole
 
 
 class WorkspaceMembershipOut(WorkspaceMembershipBase):

--- a/backend/app/services/workspaces.py
+++ b/backend/app/services/workspaces.py
@@ -62,9 +62,32 @@ class WorkspaceService:
         await self.repo.delete(workspace_id)
         await self.session.commit()
 
-    async def add_member(self, workspace_id: UUID, user_id: UUID, role: WorkspaceRole) -> None:
-        await self.repo.add_member(workspace_id, user_id, role)
+    async def set_member_role(
+        self, workspace_id: UUID, user_id: UUID, role: WorkspaceRole
+    ) -> tuple[WorkspaceMembershipOut, UUID | None]:
+        """Returns (updated membership, displaced_owner_id).
+
+        displaced_owner_id is set when ownership is transferred so the caller
+        can invalidate the former owner's cached role.
+        """
+        current_owner = await self.repo.get_workspace_owner(workspace_id)
+        displaced_owner_id: UUID | None = None
+
+        if role == WorkspaceRole.owner:
+            # Transfer ownership: demote the current owner to admin first.
+            if current_owner and current_owner.user_id != user_id:
+                current_owner.role = WorkspaceRole.admin
+                displaced_owner_id = current_owner.user_id
+        elif current_owner and current_owner.user_id == user_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Cannot demote the workspace owner. Transfer ownership to another member first.",
+            )
+
+        membership = await self.repo.set_member_role(workspace_id, user_id, role)
         await self.session.commit()
+        await self.session.refresh(membership)
+        return WorkspaceMembershipOut.model_validate(membership), displaced_owner_id
 
     async def find_user_role(self, workspace_id: UUID, user_id: UUID) -> WorkspaceRole | None:
         """Return the user's workspace role, or None if not a member. Does not raise on miss."""

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -18,14 +18,6 @@ class Settings(BaseSettings):
     logger_file: str | None = Field(None, alias="LOGGER_FILE")
     db_url: str = ""
 
-    # Test database configuration (optional — not required in production)
-    test_db_name: str | None = Field(None, alias="TEST_DB_NAME")
-    test_db_user: str | None = Field(None, alias="TEST_DB_USER")
-    test_db_password: str | None = Field(None, alias="TEST_DB_PASSWORD")
-    test_db_port: str | None = Field(None, alias="TEST_DB_PORT")
-    test_db_host: str | None = Field(None, alias="TEST_DB_HOST")
-    test_db_url: str = ""
-
     # Auth0 configuration
     auth0_domain: str = Field(..., alias="AUTH0_DOMAIN")
     auth0_audience: str = Field(..., alias="AUTH0_AUDIENCE")
@@ -58,18 +50,6 @@ class Settings(BaseSettings):
     def model_post_init(self, __context: object) -> None:
         # Production database URL
         self.db_url = f"postgresql+psycopg://{self.db_user}:{self.db_password}@{self.db_host}:{self.db_port}/{self.db_name}"
-
-        # Test database URL (only built when test DB vars are present)
-        if all(
-            [
-                self.test_db_user,
-                self.test_db_password,
-                self.test_db_host,
-                self.test_db_port,
-                self.test_db_name,
-            ]
-        ):
-            self.test_db_url = f"postgresql+psycopg://{self.test_db_user}:{self.test_db_password}@{self.test_db_host}:{self.test_db_port}/{self.test_db_name}"
 
 
 settings: Settings = Settings()  # type: ignore[call-arg]

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -25,6 +25,7 @@ from app.domain.enums import EventInterval, Permissions, Weekday, WorkspaceRole
 from app.models.tag import Tag
 from app.models.user import User
 from app.models.workspace import Workspace, WorkspaceMembership
+from app.schemas.workspace import get_first_monday_of_september
 from app.settings import settings
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
@@ -44,7 +45,10 @@ _default_output_dir = str(Path(__file__).parent)
 OUTPUT_FILE = Path(os.getenv("SEED_OUTPUT_DIR", _default_output_dir)) / "seed_output.json"
 
 # Emails that should always be promoted to admin (from ADMIN_EMAILS in .env), or if that value is not found we add halldor@svanir.is
-ADMIN_EMAILS: list[str] = settings.admin_email_list or ["halldor@svanir.is"]
+ADMIN_EMAILS: list[str] = settings.admin_email_list or [
+    "halldor@svanir.is",
+    "signy.kristin8@gmail.com",
+]
 
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
@@ -70,13 +74,6 @@ async def get_or_create_user(session: AsyncSession) -> User:
     return user
 
 
-def _first_monday_of_september() -> dt.date:
-    year = dt.date.today().year
-    sep1 = dt.date(year, 9, 1)
-    days_to_monday = (7 - sep1.weekday()) % 7
-    return sep1 + dt.timedelta(days=days_to_monday)
-
-
 async def get_or_create_workspace(session: AsyncSession, user: User) -> Workspace:
     # Check if a workspace with this name already belongs to the user.
     result = await session.execute(
@@ -85,6 +82,7 @@ async def get_or_create_workspace(session: AsyncSession, user: User) -> Workspac
         .where(
             WorkspaceMembership.user_id == user.id,
             Workspace.name == WORKSPACE_NAME,
+            Workspace.deleted_at.is_(None),
         )
     )
     ws = result.scalars().first()
@@ -99,7 +97,7 @@ async def get_or_create_workspace(session: AsyncSession, user: User) -> Workspac
         default_start_time=dt.time(hour=20, minute=0),
         default_end_time=dt.time(hour=21, minute=30),
         default_interval=EventInterval.weekly,
-        season_start=_first_monday_of_september(),
+        season_start=get_first_monday_of_september(),
     )
     session.add(ws)
     await session.flush()  # populate ws.id

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,136 @@
+"""Unit tests for get_current_user — auto-add to default workspace."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.core.auth import get_current_user
+from app.domain.enums import Permissions, WorkspaceRole
+from app.schemas.user import UserOut
+
+
+@pytest.fixture
+def new_user():
+    return UserOut(
+        id=uuid4(),
+        auth0_id="auth0|new_user",
+        email="new@example.com",
+        name="New User",
+        pronouns=None,
+        permissions=Permissions.viewer,
+        preferences=None,
+    )
+
+
+@pytest.fixture
+def mock_credentials():
+    creds = MagicMock()
+    creds.credentials = "fake.jwt.token"
+    return creds
+
+
+@pytest.fixture
+def mock_session():
+    return AsyncMock()
+
+
+@pytest.mark.asyncio
+async def test_new_user_added_to_default_workspace(new_user, mock_credentials, mock_session):
+    """New users are added to the default workspace with viewer role when DEFAULT_WORKSPACE_ID is set."""
+    default_ws_id = uuid4()
+
+    with (
+        patch("app.core.auth.asyncio.to_thread", new_callable=AsyncMock) as mock_verify,
+        patch("app.core.auth.user_cache.get", new_callable=AsyncMock, return_value=None),
+        patch("app.core.auth.user_cache.set", new_callable=AsyncMock),
+        patch("app.core.auth.UserService") as MockUserService,
+        patch("app.core.auth.WorkspaceService") as MockWorkspaceService,
+        patch("app.core.auth._DEFAULT_WORKSPACE_ID", default_ws_id),
+    ):
+        mock_payload = MagicMock()
+        mock_payload.sub = new_user.auth0_id
+        mock_payload.email = new_user.email
+        mock_payload.name = new_user.name
+        mock_verify.return_value = mock_payload
+
+        user_svc = AsyncMock()
+        user_svc.get_by_auth0_id.return_value = None
+        user_svc.create.return_value = new_user
+        MockUserService.return_value = user_svc
+
+        ws_svc = AsyncMock()
+        MockWorkspaceService.return_value = ws_svc
+
+        result = await get_current_user(mock_credentials, mock_session)
+
+        assert result == new_user
+        ws_svc.set_member_role.assert_awaited_once_with(
+            default_ws_id, new_user.id, WorkspaceRole.viewer
+        )
+
+
+@pytest.mark.asyncio
+async def test_new_user_no_default_workspace(new_user, mock_credentials, mock_session):
+    """WorkspaceService is not called when DEFAULT_WORKSPACE_ID is not set."""
+    with (
+        patch("app.core.auth.asyncio.to_thread", new_callable=AsyncMock) as mock_verify,
+        patch("app.core.auth.user_cache.get", new_callable=AsyncMock, return_value=None),
+        patch("app.core.auth.user_cache.set", new_callable=AsyncMock),
+        patch("app.core.auth.UserService") as MockUserService,
+        patch("app.core.auth.WorkspaceService") as MockWorkspaceService,
+        patch("app.core.auth._DEFAULT_WORKSPACE_ID", None),
+    ):
+        mock_payload = MagicMock()
+        mock_payload.sub = new_user.auth0_id
+        mock_payload.email = new_user.email
+        mock_payload.name = new_user.name
+        mock_verify.return_value = mock_payload
+
+        user_svc = AsyncMock()
+        user_svc.get_by_auth0_id.return_value = None
+        user_svc.create.return_value = new_user
+        MockUserService.return_value = user_svc
+
+        ws_svc = AsyncMock()
+        MockWorkspaceService.return_value = ws_svc
+
+        result = await get_current_user(mock_credentials, mock_session)
+
+        assert result == new_user
+        ws_svc.set_member_role.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_workspace_add_failure_doesnt_block_login(new_user, mock_credentials, mock_session):
+    """A failure adding the user to the default workspace does not prevent login."""
+    default_ws_id = uuid4()
+
+    with (
+        patch("app.core.auth.asyncio.to_thread", new_callable=AsyncMock) as mock_verify,
+        patch("app.core.auth.user_cache.get", new_callable=AsyncMock, return_value=None),
+        patch("app.core.auth.user_cache.set", new_callable=AsyncMock),
+        patch("app.core.auth.UserService") as MockUserService,
+        patch("app.core.auth.WorkspaceService") as MockWorkspaceService,
+        patch("app.core.auth._DEFAULT_WORKSPACE_ID", default_ws_id),
+        patch("app.core.auth.logger") as mock_logger,
+    ):
+        mock_payload = MagicMock()
+        mock_payload.sub = new_user.auth0_id
+        mock_payload.email = new_user.email
+        mock_payload.name = new_user.name
+        mock_verify.return_value = mock_payload
+
+        user_svc = AsyncMock()
+        user_svc.get_by_auth0_id.return_value = None
+        user_svc.create.return_value = new_user
+        MockUserService.return_value = user_svc
+
+        ws_svc = AsyncMock()
+        ws_svc.set_member_role.side_effect = Exception("DB unavailable")
+        MockWorkspaceService.return_value = ws_svc
+
+        result = await get_current_user(mock_credentials, mock_session)
+
+        assert result == new_user
+        mock_logger.warning.assert_called_once()


### PR DESCRIPTION
- Add PUT /workspaces/{workspace_id}/members/{user_id}/role endpoint
- Replace add_member with set_member_role (upsert semantics) in repo/service
- Enforce single-owner invariant: setting a new owner demotes the current one to admin; directly demoting the owner is rejected with 400
- Invalidate membership cache for both affected users on ownership transfer
- Remove unused test DB settings from settings.py and .env.example
- Sync .env.example with all settings defined in settings.py
- Extract shared seed helpers into app/core/seed.py; use in config.py and seed.py
- Deduplicate _first_monday_of_september by reusing get_first_monday_of_september from schemas
- Fix seed workspace lookup to exclude soft-deleted workspaces