### PR TITLE
refactor: reorganize seed and config files

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,7 +18,7 @@ RUN uv sync --no-dev
 
 COPY alembic ./alembic
 COPY app ./app
-COPY seed.py ./
+COPY scripts ./scripts
 
 # ── Stage: test ──────────────────────────────────────────
 # Includes dev/test dependencies, runs pytest

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -38,7 +38,7 @@ run:
 	PYTHONPATH=. uv run uvicorn app.main:app --reload
 
 seed:
-	PYTHONPATH=. uv run python seed.py
+	PYTHONPATH=. uv run python scripts/seed.py
 
 # Docker commands
 docker-build:

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -24,14 +24,14 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.cache import CACHE_MISS, membership_cache, user_cache
-from app.core.config import settings
 from app.core.db import get_session
-from app.core.seed import get_default_workspace_id
+from app.core.default_workspace import get_default_workspace_id
 from app.domain.enums import GroupRole, Permissions, WorkspaceRole
 from app.schemas.user import UserCreate, UserOut
 from app.services.groups import GroupService
 from app.services.users import UserService
 from app.services.workspaces import WorkspaceService
+from app.settings import settings
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,8 +1,0 @@
-"""
-Configuration module that provides access to application settings.
-This module re-exports the settings instance for use in the auth module.
-"""
-
-from app.settings import settings
-
-__all__ = ["settings"]

--- a/backend/app/core/default_workspace.py
+++ b/backend/app/core/default_workspace.py
@@ -1,4 +1,4 @@
-"""Utilities for reading the seed_output.json produced by seed.py.
+"""Utilities for reading the seed_output.json produced by scripts/seed.py.
 
 Both auth.py (startup resolution) and routers/config.py (public endpoint)
 need to read this file — this module is the single source of truth for that
@@ -16,7 +16,7 @@ from uuid import UUID
 
 logger = logging.getLogger(__name__)
 
-# JSON key written by seed.py for the default workspace ID
+# JSON key written by scripts/seed.py for the default workspace ID
 SEED_KEY_DEFAULT_WS = "dagskrarbankinn_workspace_id"
 
 _default_seed_dir = str(Path(__file__).parent.parent.parent)

--- a/backend/app/routers/config.py
+++ b/backend/app/routers/config.py
@@ -10,7 +10,7 @@ import logging
 from fastapi import APIRouter
 from pydantic import BaseModel
 
-from app.core.seed import SEED_KEY_DEFAULT_WS, read_seed_output
+from app.core.default_workspace import SEED_KEY_DEFAULT_WS, read_seed_output
 
 logger = logging.getLogger(__name__)
 

--- a/backend/scripts/seed.py
+++ b/backend/scripts/seed.py
@@ -3,7 +3,7 @@ Seed script: creates the default 'slodi' system user and
 the 'Dagskrárbankinn' workspace, then persists their IDs to seed_output.json.
 
 Usage:
-    PYTHONPATH=. uv run python seed.py
+    PYTHONPATH=. uv run python scripts/seed.py
 or via the Makefile:
     make seed
 """
@@ -41,7 +41,7 @@ WORKSPACE_NAME = "Dagskrárbankinn"
 
 DEFAULT_TAGS = ["Leikir", "Útivist", "Samfélagsverkefni"]
 
-_default_output_dir = str(Path(__file__).parent)
+_default_output_dir = str(Path(__file__).parent.parent)
 OUTPUT_FILE = Path(os.getenv("SEED_OUTPUT_DIR", _default_output_dir)) / "seed_output.json"
 
 # Emails that should always be promoted to admin (from ADMIN_EMAILS in .env), or if that value is not found we add halldor@svanir.is


### PR DESCRIPTION
- Delete app/core/config.py (dead re-export of settings)
- Rename app/core/seed.py → app/core/default_workspace.py to clarify its role (resolving the default workspace ID) vs. the seed script
- Move seed.py → scripts/seed.py for discoverability; fix internal output path accordingly
- Update Makefile and Dockerfile to reflect new script location
- Fix import sites in auth.py and routers/config.py