### PR TITLE
fix: remove build-time Auth0 env var validation to allow Docker builds

### DIFF
--- a/frontend/lib/auth0.ts
+++ b/frontend/lib/auth0.ts
@@ -1,24 +1,5 @@
 import { Auth0Client } from "@auth0/nextjs-auth0/server";
 
-const requiredEnvVars = {
-  AUTH0_SECRET: process.env.AUTH0_SECRET,
-  AUTH0_BASE_URL: process.env.AUTH0_BASE_URL,
-  AUTH0_ISSUER_BASE_URL: process.env.AUTH0_ISSUER_BASE_URL,
-  AUTH0_CLIENT_ID: process.env.AUTH0_CLIENT_ID,
-  AUTH0_CLIENT_SECRET: process.env.AUTH0_CLIENT_SECRET,
-};
-
-const missingVars = Object.entries(requiredEnvVars)
-  .filter(([_, value]) => !value)
-  .map(([key]) => key);
-
-if (missingVars.length > 0) {
-  throw new Error(
-    `Missing required Auth0 environment variables: ${missingVars.join(", ")}\n` +
-      `Please check your .env.local file.`
-  );
-}
-
 export const auth0 = new Auth0Client({
   authorizationParameters: {
     scope: process.env.AUTH0_SCOPE ?? "openid profile email",


### PR DESCRIPTION
The SDK validates env vars at request time, so the custom upfront check was unnecessary and caused `next build` to fail when vars are only available at runtime.