### PR TITLE
fix: update seed script path in docker-compose migrations command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
         uv run alembic upgrade head &&
         echo '✅ Migrations complete!' &&
         echo '🌱 Running seed...' &&
-        PYTHONPATH=. uv run python seed.py &&
+        PYTHONPATH=. uv run python scripts/seed.py &&
         echo '✅ Seed complete!'
       "
     networks:


### PR DESCRIPTION
Seed script was moved to scripts/seed.py but the compose command still referenced the old root-level path.