### PR TITLE
fix: make docker-compose build args configurable via root .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Root .env — Docker Compose variable substitution
+# Copy to .env and adjust for your environment.
+# This file is NOT passed into containers; it only affects docker-compose.yml substitution.
+# Container-level config goes in backend/.env.docker and frontend/.env.docker.
+
+# URL of the backend API, as reachable from the browser (baked into the frontend bundle at build time).
+# Local dev default: http://localhost:8000
+# Production example: https://api.yourdomain.com
+NEXT_PUBLIC_API_URL=http://localhost:8000
+
+# Port the backend is exposed on the host (default: 8000)
+# BACKEND_PORT=8000
+
+# Port the frontend is exposed on the host (default: 3000)
+# FRONTEND_PORT=3000
+
+# PostgreSQL password (default: your_password)
+# DB_PASSWORD=your_password
+
+# Port PostgreSQL is exposed on the host (default: 5432)
+DB_EXPOSE_PORT=5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_USER: slodi_user
       POSTGRES_PASSWORD: ${DB_PASSWORD:-slodi_password}
     ports:
-      - "${DB_EXPOSE_PORT:-5454}:5432"
+      - "${DB_EXPOSE_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -88,8 +88,8 @@ services:
       target: production
       args:
         # NEXT_PUBLIC_API_URL is baked into the client bundle at build time.
-        # Must be reachable from the browser — use localhost, not the internal Docker hostname.
-        - NEXT_PUBLIC_API_URL=http://localhost:8000
+        # Must be reachable from the browser — set this in your .env file on each machine.
+        - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://localhost:8000}
     container_name: slodi-frontend
     env_file:
       - ./frontend/.env.docker


### PR DESCRIPTION
- NEXT_PUBLIC_API_URL now reads from environment instead of being hardcoded to localhost, fixing production browser API calls
- DB_EXPOSE_PORT default corrected to 5432
- Add .env.example documenting all compose-level variables