### PR TITLE
Add workspace role column to admin user management page

### DIFF
--- a/backend/app/repositories/workspaces.py
+++ b/backend/app/repositories/workspaces.py
@@ -108,6 +108,10 @@ class WorkspaceRepository(Repository):
         res = await self.session.execute(stmt)
         return res.scalars().first()
 
+    async def list_members(self, workspace_id: UUID) -> Sequence[WorkspaceMembership]:
+        stmt = select(WorkspaceMembership).where(WorkspaceMembership.workspace_id == workspace_id)
+        return await self.scalars(stmt)
+
     async def set_member_role(
         self, workspace_id: UUID, user_id: UUID, role: WorkspaceRole
     ) -> WorkspaceMembership:

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1,6 +1,7 @@
 ## backend/app/routers/users.py
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Annotated
 from uuid import UUID
 
@@ -64,6 +65,29 @@ async def get_current_user_info(
 ) -> UserOut:
     """Get the current user's own profile"""
     return current_user
+
+
+@router.get("/admin/list", response_model=list[UserOut])
+async def list_users_admin(
+    session: SessionDep,
+    request: Request,
+    response: Response,
+    current_user: UserOut = Depends(require_permission(Permissions.admin)),  # noqa: B008
+    q: str | None = DEFAULT_Q,
+    limit: Limit = 50,
+    offset: Offset = 0,
+) -> Sequence[UserOut]:
+    svc = UserService(session)
+    total = await svc.count(q=q)
+    items = await svc.list_full(q=q, limit=limit, offset=offset)
+    add_pagination_headers(
+        response=response,
+        request=request,
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
+    return items
 
 
 @router.get("/{user_id}", response_model=UserOutLimited)

--- a/backend/app/routers/workspaces.py
+++ b/backend/app/routers/workspaces.py
@@ -133,6 +133,16 @@ async def get_my_workspace_role(
     return result
 
 
+@router.get("/workspaces/{workspace_id}/members", response_model=list[WorkspaceMembershipOut])
+async def list_workspace_members(
+    session: SessionDep,
+    workspace_id: UUID,
+    current_user: UserOut = Depends(require_permission(Permissions.admin)),
+) -> list[WorkspaceMembershipOut]:
+    svc = WorkspaceService(session)
+    return await svc.list_members(workspace_id)
+
+
 @router.get("/workspaces/{workspace_id}", response_model=WorkspaceOut)
 async def get_workspace(
     session: SessionDep,

--- a/backend/app/services/users.py
+++ b/backend/app/services/users.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from uuid import UUID
 
 from fastapi import HTTPException, status
@@ -52,6 +53,12 @@ class UserService:
     ) -> list[UserOutLimited]:
         rows = await self.repo.list(q=q, limit=limit, offset=offset)
         return [UserOutLimited.model_validate(r) for r in rows]
+
+    async def list_full(
+        self, *, q: str | None, limit: int = 50, offset: int = 0
+    ) -> Sequence[UserOut]:
+        rows = await self.repo.list(q=q, limit=limit, offset=offset)
+        return [UserOut.model_validate(r) for r in rows]
 
     async def create(self, data: UserCreate) -> UserOut:
         user = User(**data.model_dump())

--- a/backend/app/services/workspaces.py
+++ b/backend/app/services/workspaces.py
@@ -62,6 +62,10 @@ class WorkspaceService:
         await self.repo.delete(workspace_id)
         await self.session.commit()
 
+    async def list_members(self, workspace_id: UUID) -> list[WorkspaceMembershipOut]:
+        rows = await self.repo.list_members(workspace_id)
+        return [WorkspaceMembershipOut.model_validate(r) for r in rows]
+
     async def set_member_role(
         self, workspace_id: UUID, user_id: UUID, role: WorkspaceRole
     ) -> tuple[WorkspaceMembershipOut, UUID | None]:

--- a/frontend/components/UserManagement/UserManagement.tsx
+++ b/frontend/components/UserManagement/UserManagement.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAuth } from "@/hooks/useAuth";
+import { useDefaultWorkspaceId } from "@/hooks/useDefaultWorkspaceId";
 import {
   adminDeleteUser,
   adminUpdateUser,
@@ -9,6 +10,11 @@ import {
   type User,
   type UserPermissions,
 } from "@/services/users.service";
+import {
+  getWorkspaceMembers,
+  setWorkspaceMemberRole,
+  type WorkspaceRole,
+} from "@/services/workspaces.service";
 import styles from "./UserManagement.module.css";
 
 const PERMISSIONS: UserPermissions[] = ["viewer", "member", "admin"];
@@ -18,10 +24,19 @@ const PERMISSION_LABELS: Record<UserPermissions, string> = {
   admin: "Stjórnandi",
 };
 
+const WORKSPACE_ROLES: WorkspaceRole[] = ["viewer", "editor", "admin"];
+const WORKSPACE_ROLE_LABELS: Record<WorkspaceRole, string> = {
+  viewer: "Skoðandi",
+  editor: "Ritstjóri",
+  admin: "Stjórnandi",
+  owner: "Eigandi",
+};
+
 const PAGE_SIZE = 20;
 
 export default function UserManagement() {
   const { user: currentUser, getToken, isLoading: authLoading } = useAuth();
+  const defaultWorkspaceId = useDefaultWorkspaceId();
   const [users, setUsers] = useState<User[]>([]);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(0);
@@ -32,6 +47,8 @@ export default function UserManagement() {
   const [pendingUpdates, setPendingUpdates] = useState<Record<string, boolean>>({});
   const [pendingDeletes, setPendingDeletes] = useState<Record<string, boolean>>({});
   const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
+  const [wsRoles, setWsRoles] = useState<Record<string, WorkspaceRole>>({});
+  const [pendingWsUpdates, setPendingWsUpdates] = useState<Record<string, boolean>>({});
 
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -51,19 +68,33 @@ export default function UserManagement() {
     setLoading(true);
     setError(null);
     try {
-      const result = await listUsers(token, {
-        q: debouncedSearch.length >= 2 ? debouncedSearch : undefined,
-        limit: PAGE_SIZE,
-        offset: page * PAGE_SIZE,
-      });
+      const fetchMembers = defaultWorkspaceId
+        ? getWorkspaceMembers(defaultWorkspaceId, token).catch(() => [])
+        : Promise.resolve([]);
+
+      const [result, members] = await Promise.all([
+        listUsers(token, {
+          q: debouncedSearch.length >= 2 ? debouncedSearch : undefined,
+          limit: PAGE_SIZE,
+          offset: page * PAGE_SIZE,
+        }),
+        fetchMembers,
+      ]);
+
       setUsers(result.items);
       setTotal(result.total);
+
+      const roleMap: Record<string, WorkspaceRole> = {};
+      for (const m of members) {
+        roleMap[m.user_id] = m.role;
+      }
+      setWsRoles(roleMap);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Gat ekki sótt notendur");
     } finally {
       setLoading(false);
     }
-  }, [getToken, debouncedSearch, page]);
+  }, [getToken, debouncedSearch, page, defaultWorkspaceId]);
 
   useEffect(() => {
     if (!authLoading) fetchUsers();
@@ -85,6 +116,21 @@ export default function UserManagement() {
     }
   };
 
+  const handleWsRoleChange = async (userId: string, role: WorkspaceRole) => {
+    if (!defaultWorkspaceId) return;
+    const token = await getToken();
+    if (!token) return;
+    setPendingWsUpdates((prev) => ({ ...prev, [userId]: true }));
+    try {
+      const updated = await setWorkspaceMemberRole(defaultWorkspaceId, userId, role, token);
+      setWsRoles((prev) => ({ ...prev, [userId]: updated.role }));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Gat ekki uppfært aðgang að dagskrárbanka");
+    } finally {
+      setPendingWsUpdates((prev) => ({ ...prev, [userId]: false }));
+    }
+  };
+
   const handleDeleteConfirm = async (userId: string) => {
     const token = await getToken();
     if (!token) return;
@@ -102,6 +148,7 @@ export default function UserManagement() {
   };
 
   const totalPages = Math.ceil(total / PAGE_SIZE);
+  const colSpan = defaultWorkspaceId ? 5 : 4;
 
   if (!authLoading && currentUser?.permissions !== "admin") {
     return (
@@ -140,83 +187,115 @@ export default function UserManagement() {
               <th className={styles.th}>Nafn</th>
               <th className={styles.th}>Netfang</th>
               <th className={styles.th}>Réttindi</th>
+              {defaultWorkspaceId && <th className={styles.th}>Réttindi í dagskrárbanka</th>}
               <th className={styles.th}>Aðgerðir</th>
             </tr>
           </thead>
           <tbody>
             {loading ? (
               <tr>
-                <td colSpan={4} className={styles.centeredCell}>
+                <td colSpan={colSpan} className={styles.centeredCell}>
                   Hleð…
                 </td>
               </tr>
             ) : users.length === 0 ? (
               <tr>
-                <td colSpan={4} className={styles.centeredCell}>
+                <td colSpan={colSpan} className={styles.centeredCell}>
                   Engir notendur fundust.
                 </td>
               </tr>
             ) : (
-              users.map((u) => (
-                <tr
-                  key={u.id}
-                  className={`${styles.row} ${u.id === currentUser?.id ? styles.selfRow : ""}`}
-                >
-                  <td className={styles.td}>
-                    <span className={styles.name}>{u.name}</span>
-                    {u.id === currentUser?.id && <span className={styles.selfBadge}>þú</span>}
-                  </td>
-                  <td className={styles.td}>{u.email}</td>
-                  <td className={styles.td}>
-                    <select
-                      className={styles.permSelect}
-                      value={u.permissions}
-                      disabled={pendingUpdates[u.id] || u.id === currentUser?.id}
-                      onChange={(e) =>
-                        handlePermissionChange(u.id, e.target.value as UserPermissions)
-                      }
-                      aria-label={`Réttindi ${u.name}`}
-                    >
-                      {PERMISSIONS.map((p) => (
-                        <option key={p} value={p}>
-                          {PERMISSION_LABELS[p]}
-                        </option>
-                      ))}
-                    </select>
-                    {pendingUpdates[u.id] && <span className={styles.saving}>…</span>}
-                  </td>
-                  <td className={styles.td}>
-                    {u.id !== currentUser?.id &&
-                      (deleteConfirm === u.id ? (
-                        <span className={styles.deleteConfirmRow}>
-                          <span className={styles.deleteConfirmText}>Ertu viss?</span>
-                          <button
-                            className={styles.confirmBtn}
-                            onClick={() => handleDeleteConfirm(u.id)}
-                            disabled={pendingDeletes[u.id]}
-                          >
-                            Já, eyða
-                          </button>
-                          <button
-                            className={styles.cancelBtn}
-                            onClick={() => setDeleteConfirm(null)}
-                          >
-                            Hætta við
-                          </button>
-                        </span>
-                      ) : (
-                        <button
-                          className={styles.deleteBtn}
-                          onClick={() => setDeleteConfirm(u.id)}
-                          disabled={pendingDeletes[u.id]}
-                          aria-label={`Eyða ${u.name}`}
+              users.map((u) => {
+                const wsRole = wsRoles[u.id];
+                return (
+                  <tr
+                    key={u.id}
+                    className={`${styles.row} ${u.id === currentUser?.id ? styles.selfRow : ""}`}
+                  >
+                    <td className={styles.td}>
+                      <span className={styles.name}>{u.name}</span>
+                      {u.id === currentUser?.id && <span className={styles.selfBadge}>þú</span>}
+                    </td>
+                    <td className={styles.td}>{u.email}</td>
+                    <td className={styles.td}>
+                      <select
+                        className={styles.permSelect}
+                        value={u.permissions}
+                        disabled={pendingUpdates[u.id] || u.id === currentUser?.id}
+                        onChange={(e) =>
+                          handlePermissionChange(u.id, e.target.value as UserPermissions)
+                        }
+                        aria-label={`Réttindi ${u.name}`}
+                      >
+                        {PERMISSIONS.map((p) => (
+                          <option key={p} value={p}>
+                            {PERMISSION_LABELS[p]}
+                          </option>
+                        ))}
+                      </select>
+                      {pendingUpdates[u.id] && <span className={styles.saving}>…</span>}
+                    </td>
+                    {defaultWorkspaceId && (
+                      <td className={styles.td}>
+                        <select
+                          className={styles.permSelect}
+                          value={wsRole ?? ""}
+                          disabled={pendingWsUpdates[u.id]}
+                          onChange={(e) =>
+                            handleWsRoleChange(u.id, e.target.value as WorkspaceRole)
+                          }
+                          aria-label={`Réttindi í dagskrárbanka ${u.name}`}
                         >
-                          Eyða
-                        </button>
-                      ))}
-                  </td>
-                </tr>
-              ))
+                          {!wsRole && (
+                            <option value="" disabled>
+                              —
+                            </option>
+                          )}
+                          {wsRole === "owner" && (
+                            <option value="owner">{WORKSPACE_ROLE_LABELS.owner}</option>
+                          )}
+                          {WORKSPACE_ROLES.map((r) => (
+                            <option key={r} value={r}>
+                              {WORKSPACE_ROLE_LABELS[r]}
+                            </option>
+                          ))}
+                        </select>
+                        {pendingWsUpdates[u.id] && <span className={styles.saving}>…</span>}
+                      </td>
+                    )}
+                    <td className={styles.td}>
+                      {u.id !== currentUser?.id &&
+                        (deleteConfirm === u.id ? (
+                          <span className={styles.deleteConfirmRow}>
+                            <span className={styles.deleteConfirmText}>Ertu viss?</span>
+                            <button
+                              className={styles.confirmBtn}
+                              onClick={() => handleDeleteConfirm(u.id)}
+                              disabled={pendingDeletes[u.id]}
+                            >
+                              Já, eyða
+                            </button>
+                            <button
+                              className={styles.cancelBtn}
+                              onClick={() => setDeleteConfirm(null)}
+                            >
+                              Hætta við
+                            </button>
+                          </span>
+                        ) : (
+                          <button
+                            className={styles.deleteBtn}
+                            onClick={() => setDeleteConfirm(u.id)}
+                            disabled={pendingDeletes[u.id]}
+                            aria-label={`Eyða ${u.name}`}
+                          >
+                            Eyða
+                          </button>
+                        ))}
+                    </td>
+                  </tr>
+                );
+              })
             )}
           </tbody>
         </table>

--- a/frontend/services/users.service.ts
+++ b/frontend/services/users.service.ts
@@ -97,7 +97,7 @@ export async function listUsers(
   searchParams.set("offset", String(offset));
   if (q && q.length >= 2) searchParams.set("q", q);
 
-  const url = `${buildApiUrl("/users")}?${searchParams.toString()}`;
+  const url = `${buildApiUrl("/users/admin/list")}?${searchParams.toString()}`;
 
   const response = await fetch(url, {
     method: "GET",

--- a/frontend/services/workspaces.service.ts
+++ b/frontend/services/workspaces.service.ts
@@ -128,6 +128,60 @@ export async function getOrCreatePersonalWorkspace(token: string): Promise<Works
 }
 
 /**
+ * List all members of a workspace (admin only).
+ */
+export async function getWorkspaceMembers(
+  workspaceId: string,
+  token: string
+): Promise<WorkspaceMembership[]> {
+  const url = buildApiUrl(`/workspaces/${workspaceId}/members`);
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(`Failed to get workspace members: ${response.status} - ${errorBody}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Set a user's role in a workspace (admin only).
+ */
+export async function setWorkspaceMemberRole(
+  workspaceId: string,
+  userId: string,
+  role: WorkspaceRole,
+  token: string
+): Promise<WorkspaceMembership> {
+  const url = buildApiUrl(`/workspaces/${workspaceId}/members/${userId}/role`);
+
+  const response = await fetch(url, {
+    method: "PUT",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ role }),
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(`Failed to set workspace role: ${response.status} - ${errorBody}`);
+  }
+
+  return response.json();
+}
+
+/**
  * Get the current user's membership/role for a workspace.
  * Returns null if the user is not a member (404 from backend).
  */


### PR DESCRIPTION
- Fix admin page showing all users as viewer by adding a new GET /users/admin/list endpoint that returns full UserOut (including permissions) instead of the limited schema
- Add GET /workspaces/{workspace_id}/members endpoint (admin-only) to list all members of a workspace with their roles
- Add list_members() to WorkspaceRepository and WorkspaceService
- Add list_full() to UserService (returns UserOut instead of UserOutLimited)
- Add getWorkspaceMembers() and setWorkspaceMemberRole() to frontend workspaces service
- Add "Réttindi í dagskrárbanka" column to admin user table, showing each user's role in the default workspace with an inline dropdown to change it; column hidden when no default workspace is configured