### PR TITLE
Fix Auth0 session expiry causing stuck logout page

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       DB_HOST: postgres
       DB_PORT: 5432
       SEED_OUTPUT_DIR: /app/seed_data
+      UV_NO_SYNC: "true"
     volumes:
       - seed_data:/app/seed_data
     depends_on:
@@ -63,6 +64,7 @@ services:
       DB_HOST: postgres
       DB_PORT: 5432
       SEED_OUTPUT_DIR: /app/seed_data
+      UV_NO_SYNC: "true"
     volumes:
       - seed_data:/app/seed_data
     ports:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -18,7 +18,7 @@ AUTH0_CLIENT_SECRET=your-client-secret
 AUTH0_SECRET=your-32-char-random-secret-use-openssl-rand-base64-32
 AUTH0_REDIRECT_URI=http://localhost:3000/auth/callback
 AUTH0_POST_LOGOUT_REDIRECT_URI=http://localhost:3000/
-AUTH0_SCOPE=openid profile email
+AUTH0_SCOPE=openid profile email offline_access
 AUTH0_AUDIENCE=https://api.slodi.is
 
 # Resend (email) configuration

--- a/frontend/contexts/AuthContext.tsx
+++ b/frontend/contexts/AuthContext.tsx
@@ -41,11 +41,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const response = await fetch("/api/auth/token");
 
       if (response.status === 401) {
-        // Token expired or invalid - clear user state and force re-login
         setUser(null);
         setTokenCache(null);
-        // Redirect to logout to clear the stale Auth0 session cookie
-        window.location.href = "/api/auth/logout";
+        // Redirect to login (not logout) so the user can re-authenticate and
+        // return to exactly where they were. Their localStorage draft survives.
+        const returnTo = encodeURIComponent(window.location.pathname + window.location.search);
+        window.location.href = `/auth/login?returnTo=${returnTo}`;
         return null;
       }
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -81,8 +81,8 @@ export async function fetchWithAuth<T>(
 
   if (!response.ok) {
     if (response.status === 401) {
-      // Token expired or invalid - redirect to login
-      window.location.href = "/auth/login";
+      const returnTo = encodeURIComponent(window.location.pathname + window.location.search);
+      window.location.href = `/auth/login?returnTo=${returnTo}`;
       throw new Error("Authentication required");
     }
 

--- a/frontend/lib/auth0.ts
+++ b/frontend/lib/auth0.ts
@@ -2,7 +2,9 @@ import { Auth0Client } from "@auth0/nextjs-auth0/server";
 
 export const auth0 = new Auth0Client({
   authorizationParameters: {
-    scope: process.env.AUTH0_SCOPE ?? "openid profile email",
+    // offline_access is always appended to request a refresh token so the SDK
+    // can silently renew access tokens without redirecting the user to logout.
+    scope: `${process.env.AUTH0_SCOPE ?? "openid profile email"} offline_access`,
     audience: process.env.AUTH0_AUDIENCE,
   },
 });


### PR DESCRIPTION
- Add offline_access scope so Auth0 issues a refresh token; the SDK can now silently renew access tokens instead of initiating logout
- On 401 from /api/auth/token, redirect to /auth/login?returnTo=<path> instead of logout, so the user re-authenticates and returns to the same page with their localStorage draft intact
- Add returnTo param to the 401 redirect in fetchWithAuth (api.ts) so the correct page is restored after re-authentication
- Add UV_NO_SYNC=true to docker-compose to prevent uv from downloading dev dependencies at container runtime