### PR TITLE
fix: fetch up to 200 programs in dagskrárbanki and fix author search …

### DIFF
--- a/frontend/hooks/__tests__/useProgramFilters.test.ts
+++ b/frontend/hooks/__tests__/useProgramFilters.test.ts
@@ -57,6 +57,7 @@ const PROGRAMS: Program[] = [
     price: 0,
     like_count: 10,
     created_at: "2026-01-10T00:00:00Z",
+    author_name: "Jón Jónsson",
     author: { id: "a1", name: "Jón Jónsson", email: "jon@test.is" },
     location: "Reykjavík",
     tags: [{ id: "t1", name: "Útileikur" }],
@@ -73,6 +74,7 @@ const PROGRAMS: Program[] = [
     price: 2000,
     like_count: 5,
     created_at: "2026-02-15T00:00:00Z",
+    author_name: "Anna Sigurdsson",
     author: { id: "a2", name: "Anna Sigurdsson", email: "anna@test.is" },
     location: "Akureyri",
     tags: [{ id: "t2", name: "Gönguferð" }],
@@ -89,6 +91,7 @@ const PROGRAMS: Program[] = [
     price: 500,
     like_count: 20,
     created_at: "2026-03-01T00:00:00Z",
+    author_name: "Guðrún Helga",
     author: { id: "a3", name: "Guðrún Helga", email: "gudrun@test.is" },
     location: "Reykjavík",
     tags: [

--- a/frontend/services/programs.service.ts
+++ b/frontend/services/programs.service.ts
@@ -97,7 +97,7 @@ export async function fetchPrograms(
   workspaceId: string,
   getToken: () => Promise<string | null>
 ): Promise<Program[]> {
-  const url = buildApiUrl(`/workspaces/${workspaceId}/programs`);
+  const url = buildApiUrl(`/workspaces/${workspaceId}/programs?limit=200`);
   const data = await fetchWithAuth<ProgramsResponse>(
     url,
     {


### PR DESCRIPTION
…test

Programs were capped at 50 due to the backend default limit not being overridden in the frontend fetch call. Bumped to 200 (backend max).

Also fixes test fixtures where author_name was not overridden alongside author, causing the author name search assertion to check the wrong value.