### PR TITLE
feat: show leaderboard as bottom sheet on mobile after game over

### DIFF
--- a/frontend/app/leikir/[game]/route.ts
+++ b/frontend/app/leikir/[game]/route.ts
@@ -40,6 +40,7 @@ const LEADERBOARD_STYLES = `
   #leaderboard .lb-rank { color: #aaa; min-width: 22px; font-size: 12px; }
   #leaderboard .lb-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   #leaderboard .lb-score { color: #4db84d; font-weight: bold; }
+  #lb-handle { display: none; }
   #login-prompt {
     margin-top: 10px;
     font-size: 12px;
@@ -48,13 +49,35 @@ const LEADERBOARD_STYLES = `
   }
   #login-prompt a { color: #5c6bc0; }
   @media (max-width: 639px) {
-    body { flex-direction: column; align-items: center; padding: 8px; gap: 12px; }
-    #leaderboard { width: 100%; max-width: 400px; height: auto; max-height: 180px; }
+    body { overflow: hidden; padding: 0; gap: 0; align-items: center; }
+    #gameCanvas { max-width: 100vw; max-height: 100dvh; }
+    #leaderboard {
+      position: fixed;
+      bottom: 0; left: 0; right: 0;
+      width: 100%;
+      max-height: 60dvh;
+      height: auto;
+      border-radius: 16px 16px 0 0;
+      transform: translateY(100%);
+      transition: transform 0.32s cubic-bezier(0.4, 0, 0.2, 1);
+      z-index: 10;
+      padding: 8px 16px 24px;
+    }
+    #leaderboard.active { transform: translateY(0); }
+    #lb-handle {
+      display: block;
+      width: 40px; height: 4px;
+      background: rgba(255,255,255,0.25);
+      border-radius: 2px;
+      margin: 0 auto 14px;
+      cursor: pointer;
+    }
   }
 </style>`;
 
 const leaderboardHtml = () => `
 <div id="leaderboard">
+  <div id="lb-handle" onclick="document.getElementById('leaderboard').classList.remove('active')" role="button" aria-label="Loka stigatöflu"></div>
   <h2>Stigatafla</h2>
   <ol id="leaderboard-list"><li style="color:#aaa;font-size:12px">Hleður...</li></ol>
   <div id="login-prompt" style="display:none">

--- a/frontend/public/leikir/horpuhopp/game.js
+++ b/frontend/public/leikir/horpuhopp/game.js
@@ -98,6 +98,9 @@ function init() {
   coins = [];
   tick = 0;
 
+  var lb = document.getElementById("leaderboard");
+  if (lb) lb.classList.remove("active");
+
   player = {
     x: canvas.width / 2 - PLAYER_W / 2,
     y: canvas.height - 250,
@@ -481,9 +484,13 @@ function escapeHtml(str) {
   return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-function renderLeaderboard(scores) {
+function renderLeaderboard(scores, show) {
   var list = document.getElementById("leaderboard-list");
   if (!list) return;
+  if (show) {
+    var lb = document.getElementById("leaderboard");
+    if (lb) lb.classList.add("active");
+  }
   if (!scores || scores.length === 0) {
     list.innerHTML = '<li style="color:#aaa;font-size:12px">Engar færslur</li>';
     return;
@@ -528,12 +535,14 @@ function submitScore(finalScore) {
       if (res.status === 401) {
         var prompt = document.getElementById("login-prompt");
         if (prompt) prompt.style.display = "block";
+        var lb = document.getElementById("leaderboard");
+        if (lb) lb.classList.add("active");
         return null;
       }
       return res.json();
     })
     .then(function (data) {
-      if (data) renderLeaderboard(data);
+      if (data) renderLeaderboard(data, true);
     })
     .catch(function () {});
 }


### PR DESCRIPTION
On mobile the leaderboard slides up from the bottom when the round ends (or when the 401 login prompt fires). Tapping the handle pill dismisses it; restarting the game slides it back down automatically.