### PR TITLE
fix: don't crash the whole site when the browser blocks Web Storage

### DIFF
--- a/frontend/app/programs/components/NewProgramForm.tsx
+++ b/frontend/app/programs/components/NewProgramForm.tsx
@@ -9,6 +9,7 @@ import { useTags } from "@/hooks/useTags";
 import { useDraft } from "@/hooks/useDraft";
 import { handleApiErrorIs } from "@/lib/api-utils";
 import { useAuth } from "@/hooks/useAuth";
+import { safeLocalStorage } from "@/lib/safe-storage";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -100,7 +101,7 @@ export default function NewProgramForm({ workspaceId, onCreated, onCancel }: Pro
   useEffect(() => {
     if (typeof window === "undefined") return;
     try {
-      const stored = localStorage.getItem(draftKey);
+      const stored = safeLocalStorage.getItem(draftKey);
       if (!stored) return;
       const parsed = JSON.parse(stored) as Partial<ProgramDraft>;
       const hasContent =

--- a/frontend/app/settings/ThemeToggle.tsx
+++ b/frontend/app/settings/ThemeToggle.tsx
@@ -4,6 +4,7 @@ import { Sun, Moon, Monitor } from "lucide-react";
 import { useTheme } from "@/components/ThemeProvider";
 import { useEffect, useState } from "react";
 import styles from "./settings.module.css";
+import { safeLocalStorage } from "@/lib/safe-storage";
 
 type ThemeMode = "light" | "dark" | "system";
 
@@ -13,7 +14,7 @@ export default function ThemeToggle() {
 
   // Initialize from localStorage
   useEffect(() => {
-    const stored = localStorage.getItem("slodi-theme-mode") as ThemeMode;
+    const stored = safeLocalStorage.getItem("slodi-theme-mode") as ThemeMode;
     if (stored) {
       setSelectedMode(stored);
     } else {
@@ -45,7 +46,7 @@ export default function ThemeToggle() {
 
   const handleThemeChange = (value: ThemeMode) => {
     setSelectedMode(value);
-    localStorage.setItem("slodi-theme-mode", value);
+    safeLocalStorage.setItem("slodi-theme-mode", value);
 
     if (value === "system") {
       const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;

--- a/frontend/components/ThemeProvider/__tests__/ThemeProvider.storage.test.tsx
+++ b/frontend/components/ThemeProvider/__tests__/ThemeProvider.storage.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+import ThemeProvider from "../index";
+
+// ThemeProvider sits in the root layout, so it mounts on every page. It used to
+// read localStorage unguarded, and in Safari with "Block All Cookies" that
+// access throws a SecurityError — which React surfaces as "Application error: a
+// client-side exception has occurred", taking down the whole site rather than
+// just the theme. This is the regression test for that.
+
+const realLocal = Object.getOwnPropertyDescriptor(window, "localStorage");
+
+// jsdom has no matchMedia, and ThemeProvider consults it for the system colour
+// preference. Not part of what is under test — just enough for it to mount.
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});
+
+function blockStorage() {
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    get() {
+      throw new DOMException("The operation is insecure.", "SecurityError");
+    },
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  if (realLocal) Object.defineProperty(window, "localStorage", realLocal);
+});
+
+describe("ThemeProvider in a browser that blocks storage", () => {
+  it("still renders the page instead of throwing", () => {
+    blockStorage();
+    expect(() =>
+      render(
+        <ThemeProvider>
+          <p>Dagskrárvefurinn</p>
+        </ThemeProvider>
+      )
+    ).not.toThrow();
+    expect(screen.getByText("Dagskrárvefurinn")).toBeInTheDocument();
+  });
+
+  it("renders normally when storage works", () => {
+    render(
+      <ThemeProvider>
+        <p>Dagskrárvefurinn</p>
+      </ThemeProvider>
+    );
+    expect(screen.getByText("Dagskrárvefurinn")).toBeInTheDocument();
+  });
+});

--- a/frontend/components/ThemeProvider/index.tsx
+++ b/frontend/components/ThemeProvider/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { createContext, useContext, useEffect, useState } from "react";
+import { safeLocalStorage } from "@/lib/safe-storage";
 
 type Theme = "light" | "dark" | "forest-night" | "campfire" | "northern-lights";
 type PatrolColor = "drekar" | "falkar" | "drott" | "rekkar" | "rover" | "adrir";
@@ -40,8 +41,8 @@ export default function ThemeProvider({
 
   // Load saved theme on mount
   useEffect(() => {
-    const savedTheme = localStorage.getItem(storageKey) as Theme;
-    const savedPatrol = localStorage.getItem("slodi-patrol") as PatrolColor;
+    const savedTheme = safeLocalStorage.getItem(storageKey) as Theme;
+    const savedPatrol = safeLocalStorage.getItem("slodi-patrol") as PatrolColor;
 
     if (savedTheme) {
       setThemeState(savedTheme);
@@ -76,7 +77,7 @@ export default function ThemeProvider({
     }
 
     // Save to localStorage
-    localStorage.setItem(storageKey, theme);
+    safeLocalStorage.setItem(storageKey, theme);
   }, [theme, mounted, storageKey]);
 
   // Apply patrol color as primary accent
@@ -101,7 +102,7 @@ export default function ThemeProvider({
         `var(--sl-color-patrol-${patrolColor}-muted)`
       );
 
-      localStorage.setItem("slodi-patrol", patrolColor);
+      safeLocalStorage.setItem("slodi-patrol", patrolColor);
     } else {
       // Reset to default primary (moss green)
       root.style.removeProperty("--sl-color-primary");
@@ -109,7 +110,7 @@ export default function ThemeProvider({
       root.style.removeProperty("--sl-color-primary-subtle");
       root.style.removeProperty("--sl-color-primary-muted");
 
-      localStorage.removeItem("slodi-patrol");
+      safeLocalStorage.removeItem("slodi-patrol");
     }
   }, [patrolColor, mounted]);
 

--- a/frontend/components/leikir/arnor-clicker/ArnorClickerGame.tsx
+++ b/frontend/components/leikir/arnor-clicker/ArnorClickerGame.tsx
@@ -59,6 +59,7 @@ import {
   type Upgrade,
   type Vars,
 } from "./gameData";
+import { safeLocalStorage, safeSessionStorage } from "@/lib/safe-storage";
 import styles from "./arnorClicker.module.css";
 
 const GAME = "arnor-clicker";
@@ -219,7 +220,7 @@ export default function ArnorClickerGame() {
     let alive = true;
     let loaded: LoadedSave | null = null;
     try {
-      loaded = loadSave(localStorage.getItem(SAVE_KEY));
+      loaded = loadSave(safeLocalStorage.getItem(SAVE_KEY));
     } catch {
       /* storage unavailable — start fresh */
     }
@@ -318,7 +319,7 @@ export default function ArnorClickerGame() {
       .then((res) => {
         if (res.status === 401) {
           try {
-            sessionStorage.setItem(PENDING_KEY, String(value));
+            safeSessionStorage.setItem(PENDING_KEY, String(value));
           } catch {
             /* ignore */
           }
@@ -441,7 +442,7 @@ export default function ArnorClickerGame() {
       chair: chairKeyRef.current,
     };
     try {
-      localStorage.setItem(SAVE_KEY, JSON.stringify({ ...data, sig: signSave(data) }));
+      safeLocalStorage.setItem(SAVE_KEY, JSON.stringify({ ...data, sig: signSave(data) }));
     } catch {
       /* storage full/unavailable */
     }
@@ -722,14 +723,14 @@ export default function ArnorClickerGame() {
     if (!user || pendingDone.current) return;
     let pending: string | null = null;
     try {
-      pending = sessionStorage.getItem(PENDING_KEY);
+      pending = safeSessionStorage.getItem(PENDING_KEY);
     } catch {
       /* ignore */
     }
     if (!pending) return;
     pendingDone.current = true;
     try {
-      sessionStorage.removeItem(PENDING_KEY);
+      safeSessionStorage.removeItem(PENDING_KEY);
     } catch {
       /* ignore */
     }

--- a/frontend/components/leikir/horpuhopp/HorpuhoppPage.tsx
+++ b/frontend/components/leikir/horpuhopp/HorpuhoppPage.tsx
@@ -7,6 +7,7 @@ import HorpuhoppLeaderboard, {
   type ScoreEntry,
 } from "@/components/leikir/horpuhopp/HorpuhoppLeaderboard";
 import styles from "./horpuhopp.module.css";
+import { safeSessionStorage } from "@/lib/safe-storage";
 
 const GAME = "horpuhopp";
 const PENDING_KEY = `leikir_pending_score_${GAME}`;
@@ -32,7 +33,7 @@ export default function HorpuhoppPage() {
     if (!user || pendingSubmitted.current) return;
     let pending: string | null = null;
     try {
-      pending = sessionStorage.getItem(PENDING_KEY);
+      pending = safeSessionStorage.getItem(PENDING_KEY);
     } catch {
       /* no storage */
     }
@@ -41,7 +42,7 @@ export default function HorpuhoppPage() {
     const finalScore = parseInt(pending, 10);
     if (!finalScore || finalScore <= 0) {
       try {
-        sessionStorage.removeItem(PENDING_KEY);
+        safeSessionStorage.removeItem(PENDING_KEY);
       } catch {
         /* ignore */
       }
@@ -56,7 +57,7 @@ export default function HorpuhoppPage() {
     })
       .then((res) => {
         try {
-          sessionStorage.removeItem(PENDING_KEY);
+          safeSessionStorage.removeItem(PENDING_KEY);
         } catch {
           /* ignore */
         }
@@ -71,7 +72,7 @@ export default function HorpuhoppPage() {
       })
       .catch(() => {
         try {
-          sessionStorage.removeItem(PENDING_KEY);
+          safeSessionStorage.removeItem(PENDING_KEY);
         } catch {
           /* ignore */
         }
@@ -96,7 +97,7 @@ export default function HorpuhoppPage() {
       .then((res) => {
         if (res.status === 401) {
           try {
-            sessionStorage.setItem(PENDING_KEY, String(finalScore));
+            safeSessionStorage.setItem(PENDING_KEY, String(finalScore));
           } catch {
             /* no storage */
           }

--- a/frontend/contexts/FavoritesContext.tsx
+++ b/frontend/contexts/FavoritesContext.tsx
@@ -2,6 +2,7 @@
 
 import React, { createContext, useContext, useState, useEffect, useCallback } from "react";
 import { checkResponse } from "@/lib/api-utils";
+import { safeLocalStorage } from "@/lib/safe-storage";
 
 interface FavoritesContextValue {
   favorites: Set<string>;
@@ -29,7 +30,7 @@ export function FavoritesProvider({ children }: { children: React.ReactNode }) {
       // setFavorites(new Set(data.programIds));
 
       // For now, load from localStorage as fallback
-      const stored = localStorage.getItem("favorite-programs");
+      const stored = safeLocalStorage.getItem("favorite-programs");
       if (stored) {
         const parsed = JSON.parse(stored);
         setFavorites(new Set(parsed));
@@ -69,7 +70,7 @@ export function FavoritesProvider({ children }: { children: React.ReactNode }) {
     } else {
       updatedSet.add(programId);
     }
-    localStorage.setItem("favorite-programs", JSON.stringify(Array.from(updatedSet)));
+    safeLocalStorage.setItem("favorite-programs", JSON.stringify(Array.from(updatedSet)));
 
     try {
       // TODO: Replace with actual API call when backend is ready
@@ -106,7 +107,7 @@ export function FavoritesProvider({ children }: { children: React.ReactNode }) {
       } else {
         favorites.delete(programId);
       }
-      localStorage.setItem("favorite-programs", JSON.stringify(Array.from(favorites)));
+      safeLocalStorage.setItem("favorite-programs", JSON.stringify(Array.from(favorites)));
 
       console.error("Failed to update favorite:", error);
       // You could show a toast notification here

--- a/frontend/hooks/useDefaultWorkspaceId.ts
+++ b/frontend/hooks/useDefaultWorkspaceId.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { safeSessionStorage } from "@/lib/safe-storage";
 
 /**
  * Resolve the default (shared program bank) workspace ID.
@@ -15,7 +16,9 @@ export function useDefaultWorkspaceId(): string | null {
   useEffect(() => {
     // Check session cache first to avoid a fetch on every render.
     const cached =
-      typeof sessionStorage !== "undefined" ? sessionStorage.getItem("default_workspace_id") : null;
+      typeof sessionStorage !== "undefined"
+        ? safeSessionStorage.getItem("default_workspace_id")
+        : null;
 
     if (cached) {
       setWorkspaceId(cached);
@@ -31,7 +34,7 @@ export function useDefaultWorkspaceId(): string | null {
         const data = await res.json();
         const id: string | undefined = data?.default_workspace_id;
         if (id && !cancelled) {
-          sessionStorage.setItem("default_workspace_id", id);
+          safeSessionStorage.setItem("default_workspace_id", id);
           setWorkspaceId(id);
         }
       } catch {

--- a/frontend/hooks/useDraft.ts
+++ b/frontend/hooks/useDraft.ts
@@ -1,9 +1,10 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { safeLocalStorage } from "@/lib/safe-storage";
 
 /**
- * useDraft — persists form draft state to localStorage.
+ * useDraft — persists form draft state to safeLocalStorage.
  *
  * Cookie-based persistence was considered, but the instructions field allows
  * up to 5 000 characters, which exceeds the 4 KB per-cookie browser limit.
@@ -30,7 +31,7 @@ export function useDraft<T extends object>(
   const [draft, setDraft] = useState<T>(() => {
     if (typeof window === "undefined") return initial;
     try {
-      const stored = localStorage.getItem(key);
+      const stored = safeLocalStorage.getItem(key);
       if (!stored) return initial;
       return { ...initial, ...(JSON.parse(stored) as Partial<T>) };
     } catch {
@@ -43,7 +44,7 @@ export function useDraft<T extends object>(
   useEffect(() => {
     if (typeof window === "undefined") return;
     try {
-      const stored = localStorage.getItem(key);
+      const stored = safeLocalStorage.getItem(key);
       hasDraft.current = stored !== null;
     } catch {
       // ignore
@@ -59,7 +60,7 @@ export function useDraft<T extends object>(
     if (writeTimer.current) clearTimeout(writeTimer.current);
     writeTimer.current = setTimeout(() => {
       try {
-        localStorage.setItem(key, JSON.stringify(draft));
+        safeLocalStorage.setItem(key, JSON.stringify(draft));
       } catch {
         // Quota exceeded or private-browsing restriction — fail silently.
       }
@@ -77,7 +78,7 @@ export function useDraft<T extends object>(
     setDraft(initial);
     if (typeof window !== "undefined") {
       try {
-        localStorage.removeItem(key);
+        safeLocalStorage.removeItem(key);
       } catch {
         // ignore
       }

--- a/frontend/lib/__tests__/safe-storage.test.ts
+++ b/frontend/lib/__tests__/safe-storage.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, afterEach, vi } from "vitest";
+
+import { safeLocalStorage, safeSessionStorage, storageAvailable } from "../safe-storage";
+
+// Safari with "Block All Cookies" blocks Web Storage too, and *accessing the
+// property* raises a SecurityError — it does not merely return null. One
+// unguarded read in a root-layout provider therefore throws during mount and
+// React turns it into "Application error: a client-side exception has occurred",
+// taking down every page rather than one feature. These tests reproduce that
+// browser exactly.
+
+const realLocal = Object.getOwnPropertyDescriptor(window, "localStorage");
+const realSession = Object.getOwnPropertyDescriptor(window, "sessionStorage");
+
+/** Make `window.localStorage` throw on access, as blocked Safari does. */
+function blockStorage(prop: "localStorage" | "sessionStorage") {
+  Object.defineProperty(window, prop, {
+    configurable: true,
+    get() {
+      throw new DOMException("The operation is insecure.", "SecurityError");
+    },
+  });
+}
+
+/** Storage that exists but rejects writes, as a full quota does. */
+function fullStorage(prop: "localStorage" | "sessionStorage") {
+  Object.defineProperty(window, prop, {
+    configurable: true,
+    value: {
+      getItem: () => null,
+      setItem: () => {
+        throw new DOMException("QuotaExceeded", "QuotaExceededError");
+      },
+      removeItem: () => {
+        throw new DOMException("QuotaExceeded", "QuotaExceededError");
+      },
+    },
+  });
+}
+
+afterEach(() => {
+  if (realLocal) Object.defineProperty(window, "localStorage", realLocal);
+  if (realSession) Object.defineProperty(window, "sessionStorage", realSession);
+  vi.restoreAllMocks();
+});
+
+describe("safeLocalStorage when storage works normally", () => {
+  it("round-trips a value", () => {
+    safeLocalStorage.setItem("k", "v");
+    expect(safeLocalStorage.getItem("k")).toBe("v");
+    safeLocalStorage.removeItem("k");
+    expect(safeLocalStorage.getItem("k")).toBeNull();
+  });
+
+  it("reports storage as available", () => {
+    expect(storageAvailable()).toBe(true);
+  });
+
+  it("returns null for a key that was never set", () => {
+    expect(safeLocalStorage.getItem("never-set")).toBeNull();
+  });
+});
+
+describe("safeLocalStorage when the browser blocks storage (Safari, cookies off)", () => {
+  it("does not throw on read — this is the crash that took the site down", () => {
+    blockStorage("localStorage");
+    expect(() => safeLocalStorage.getItem("slodi-theme-mode")).not.toThrow();
+    expect(safeLocalStorage.getItem("slodi-theme-mode")).toBeNull();
+  });
+
+  it("does not throw on write", () => {
+    blockStorage("localStorage");
+    expect(() => safeLocalStorage.setItem("slodi-theme-mode", "dark")).not.toThrow();
+  });
+
+  it("does not throw on remove", () => {
+    blockStorage("localStorage");
+    expect(() => safeLocalStorage.removeItem("slodi-patrol")).not.toThrow();
+  });
+
+  it("reports storage as unavailable", () => {
+    blockStorage("localStorage");
+    expect(storageAvailable()).toBe(false);
+  });
+});
+
+describe("safeLocalStorage when the quota is full", () => {
+  it("drops the write rather than throwing", () => {
+    fullStorage("localStorage");
+    expect(() => safeLocalStorage.setItem("favorite-programs", "[]")).not.toThrow();
+  });
+
+  it("still reads without throwing", () => {
+    fullStorage("localStorage");
+    expect(safeLocalStorage.getItem("favorite-programs")).toBeNull();
+  });
+});
+
+describe("safeSessionStorage", () => {
+  it("round-trips normally", () => {
+    safeSessionStorage.setItem("s", "1");
+    expect(safeSessionStorage.getItem("s")).toBe("1");
+    safeSessionStorage.removeItem("s");
+    expect(safeSessionStorage.getItem("s")).toBeNull();
+  });
+
+  it("survives a browser that blocks it", () => {
+    blockStorage("sessionStorage");
+    expect(() => safeSessionStorage.getItem("leikir_pending_score_arnor-clicker")).not.toThrow();
+    expect(() =>
+      safeSessionStorage.setItem("leikir_pending_score_arnor-clicker", "5")
+    ).not.toThrow();
+    expect(() => safeSessionStorage.removeItem("leikir_pending_score_arnor-clicker")).not.toThrow();
+  });
+
+  it("is independent of localStorage being blocked", () => {
+    blockStorage("localStorage");
+    safeSessionStorage.setItem("still", "works");
+    expect(safeSessionStorage.getItem("still")).toBe("works");
+  });
+});

--- a/frontend/lib/safe-storage.ts
+++ b/frontend/lib/safe-storage.ts
@@ -1,0 +1,92 @@
+/**
+ * Web Storage that cannot crash the page.
+ *
+ * `localStorage` is not always reachable, and the failure is not the gentle
+ * "returns null" people expect — *touching the property throws*:
+ *
+ * - Safari with "Block All Cookies" blocks Web Storage too, and every access
+ *   raises a SecurityError. This is the case that took slodi.is down for an
+ *   iPhone user: she blocked cookies to get past a 400 from the reverse proxy,
+ *   which then put her into a storage-blocked browser, and the first unguarded
+ *   `localStorage.getItem` in a root-layout provider threw during mount — which
+ *   React surfaces as "Application error: a client-side exception has occurred".
+ * - Safari private browsing has historically thrown QuotaExceededError on write.
+ * - Any browser throws QuotaExceededError once the origin's quota is full.
+ * - Server-side rendering has no `window` at all.
+ *
+ * Because a provider in the root layout runs on *every* page, one unguarded
+ * access takes down the whole site rather than one feature. These helpers
+ * degrade to "no storage available" instead: reads give null, writes are
+ * dropped. Anything persisted is a convenience — theme, favourites, a game
+ * save — so losing it is always better than losing the page.
+ */
+
+function storage(): Storage | null {
+  try {
+    // Access alone can throw, so it has to be inside the try.
+    return typeof window === "undefined" ? null : window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function sessionStorageOrNull(): Storage | null {
+  try {
+    return typeof window === "undefined" ? null : window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+/** Is Web Storage usable at all? Useful for hiding features that need it. */
+export function storageAvailable(): boolean {
+  return storage() !== null;
+}
+
+export const safeLocalStorage = {
+  getItem(key: string): string | null {
+    try {
+      return storage()?.getItem(key) ?? null;
+    } catch {
+      return null;
+    }
+  },
+  setItem(key: string, value: string): void {
+    try {
+      storage()?.setItem(key, value);
+    } catch {
+      /* storage blocked or full — the value is a convenience, not a record */
+    }
+  },
+  removeItem(key: string): void {
+    try {
+      storage()?.removeItem(key);
+    } catch {
+      /* nothing to do — see setItem */
+    }
+  },
+};
+
+export const safeSessionStorage = {
+  getItem(key: string): string | null {
+    try {
+      return sessionStorageOrNull()?.getItem(key) ?? null;
+    } catch {
+      return null;
+    }
+  },
+  setItem(key: string, value: string): void {
+    try {
+      sessionStorageOrNull()?.setItem(key, value);
+    } catch {
+      /* see safeLocalStorage.setItem */
+    }
+  },
+  removeItem(key: string): void {
+    try {
+      sessionStorageOrNull()?.removeItem(key);
+    } catch {
+      /* see safeLocalStorage.setItem */
+    }
+  },
+};


### PR DESCRIPTION
Reported by Signý, Safari on iPhone. Two errors in sequence:

1. The reverse proxy returned **400 "Request Header Or Cookie Too Large"**.
2. She blocked cookies to get past it — and then slodi.is showed **"Application error: a client-side exception has occurred"**.

**The second follows from the first.** Safari's "Block All Cookies" blocks Web Storage too, and there *accessing the property* raises a `SecurityError` — it does not merely return null. `ThemeProvider` sits in the root layout, so it mounts on every page, and it read `localStorage` unguarded. One throw during mount is all it takes: React converts it into the error boundary and **the entire site goes down rather than just the theme**.

## The fix

`lib/safe-storage.ts` degrades to "no storage available" instead of throwing — reads give null, writes are dropped — and every storage access in the app now goes through it. Everything persisted this way is a convenience (theme, patrol colour, favourites, form drafts, a game save), so losing it always beats losing the page. The same guard covers Safari private browsing and a full quota.

Previously unguarded: **`ThemeProvider` (5 accesses, root layout)**, `ThemeToggle`, and the writes in **`FavoritesContext` (also root layout)**. The rest were already wrapped individually; they now share the one helper so the invariant is uniform and greppable.

## Testing

288 frontend tests. The new suites simulate the exact browser: storage that throws on property access, and storage that throws on write.

**The regression test was verified to actually catch the bug** — I temporarily restored the unguarded code and confirmed it fails with `SecurityError`, then passes again with the fix. A test that passes either way would have been worthless.

## What this does *not* fix

The **400** itself. The Auth0 session is stored statelessly in an encrypted cookie, and with `offline_access` requesting a refresh token it holds ID + access + refresh tokens plus the profile. Encryption inflates it, the SDK chunks it across `__session.0`, `.1`, `.2`…, and every request carries all chunks — past nginx's default `large_client_header_buffers 4 8k`. That fits the evidence: anonymous requests are fine (`/`, `/leikir/arnor-clicker`, `/about` all 200 with no `Set-Cookie`), so it hits logged-in users only.

Two options, neither in this repo:
- **Immediate:** `large_client_header_buffers 4 32k;` on the Azure VM — there is no nginx config in the repository.
- **Durable:** a server-side `sessionStore` (supported by `@auth0/nextjs-auth0` v4, which is what we're on) so the cookie carries only a session ID. The backend already has a Redis-capable cache layer.

Worth noting the error page said **nginx/1.23.0** while slodi.is currently serves **1.24.0**, so that screenshot may predate an upgrade or come from a different host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)