### PR TITLE
fix(leikir): free the scroll on mobile

### DIFF
--- a/frontend/components/leikir/arnor-clicker/arnorClicker.module.css
+++ b/frontend/components/leikir/arnor-clicker/arnorClicker.module.css
@@ -1180,6 +1180,10 @@
   .game {
     flex-direction: column;
     height: auto;
+    /* The desktop layout is a fixed-height two-column frame. Stacked on a
+       phone the page itself is the scroller, so the frame must not impose a
+       viewport-sized floor. */
+    min-height: 0;
   }
   .play {
     min-height: 500px;
@@ -1188,6 +1192,26 @@
     width: auto;
     border-left: none;
     border-top: 3px solid hsl(var(--ink));
+  }
+  /* The scroll trap: on desktop these lists own their own scrolling inside a
+     fixed-height panel, and `overscroll-behavior: contain` deliberately stops
+     that scroll chaining to the page behind them. Stacked on a phone the page
+     is what scrolls, so an inner scroller just swallows the gesture — put a
+     finger over the fundarsköp list and you scroll the list, hit its end, and
+     the page never takes over. You end up stranded, unable to get back up.
+     Let the lists take their natural height and hand scrolling to the page. */
+  .cards,
+  .thing {
+    overflow: visible;
+    overscroll-behavior: auto;
+    flex: none;
+  }
+  /* Keep the tab strip reachable while a long list scrolls past it, so you can
+     switch tabs without hunting back up the page. */
+  .ptabs {
+    position: sticky;
+    top: 0;
+    z-index: 20;
   }
   .arnor img {
     height: 215px;


### PR DESCRIPTION
Reported by Rafnar: *"Er alltaf að festast þegar ég reyni að kaupa fundarsköp. Þá get ég ekki scrollað aftur upp."*

## Cause

On desktop the game is a fixed-height two-column frame, and the panel's lists (`.cards`, `.thing`) own their scrolling inside it. `overscroll-behavior: contain` is deliberate there — it stops the inner scroll chaining out to the page behind.

Stacked on a phone, `.game` becomes `height: auto` and **the page itself is the scroller** — but the lists kept both `overflow-y: auto` and `overscroll-behavior: contain`. So a finger over the fundarsköp list scrolls the list, reaches its end, and the page never takes over. You're stranded partway down with no way back up. Exactly what he described, and it happens precisely when buying, because that's when your finger is over the list.

## Fix

On mobile the lists take their natural height and hand scrolling to the page. Also:

- the tab strip is **sticky**, so tabs stay reachable while a long list runs past
- the frame's viewport-sized `min-height` is dropped — it only makes sense for the two-column layout

288 tests pass, build clean.

**Not visually verified** — no browser tooling in my environment, so this is reasoned from the CSS rather than seen working on a phone. Worth someone loading it on a handset before merge; Rafnar is the natural check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)