### PR TITLE
balance(leikir): square-root the permanent Þingstig boost

### DIFF
--- a/frontend/components/leikir/arnor-clicker/ArnorClickerGame.tsx
+++ b/frontend/components/leikir/arnor-clicker/ArnorClickerGame.tsx
@@ -50,7 +50,8 @@ import {
   GOLDEN_EVERY_MIN_S,
   GOLDEN_EVERY_MAX_S,
   GOLDEN_ON_SCREEN_MS,
-  PRESTIGE_MULT_PER_POINT,
+  prestigeBonusPct,
+  prestigeBonusGainPct,
   type Buff,
   type Chair,
   type GoldenVariant,
@@ -984,7 +985,7 @@ export default function ArnorClickerGame() {
                   </li>
                   <li>
                     <span>Varanleg uppörvun</span>
-                    <span>+{Math.round(PRESTIGE_MULT_PER_POINT * tsCur * 100)}%</span>
+                    <span>+{Math.round(prestigeBonusPct(tsCur)).toLocaleString("is-IS")}%</span>
                   </li>
                 </ol>
               </div>
@@ -1137,7 +1138,7 @@ export default function ArnorClickerGame() {
             </button>
             <div className={styles.sub}>
               {canPrestige
-                ? `Þú færð ${prestigeGain} Þingstig · +${Math.round(PRESTIGE_MULT_PER_POINT * prestigeGain * 100)}% varanlega`
+                ? `Þú færð ${prestigeGain} Þingstig · +${Math.round(prestigeBonusGainPct(tsCur, prestigeGain)).toLocaleString("is-IS")}% varanlega`
                 : "Safnaðu fleiri fundarstig til að fresta þinginu"}
             </div>
           </div>

--- a/frontend/components/leikir/arnor-clicker/__tests__/ArnorClickerGame.test.tsx
+++ b/frontend/components/leikir/arnor-clicker/__tests__/ArnorClickerGame.test.tsx
@@ -15,7 +15,7 @@ vi.mock("next/image", () => ({
 }));
 
 import ArnorClickerGame from "../ArnorClickerGame";
-import { WORKERS, CHAIRS, COMBO_BASE, signSave } from "../gameData";
+import { WORKERS, CHAIRS, COMBO_BASE, signSave, prestigeBonusPct } from "../gameData";
 
 const SAVE_KEY = "arnor_clicker_save_v2";
 
@@ -100,9 +100,11 @@ describe("ArnorClickerGame", () => {
 
       expect(within(chairCard("Aron")).getByText("Virkur")).toBeInTheDocument();
       expect(within(chairCard("Arnór")).getByText("Velja")).toBeInTheDocument();
-      // 100 - 50, and the permanent boost falls with it: 50 × 0.5% = 25%.
+      // 100 - 50, and the permanent boost falls with it, along the √ curve.
       expect(stat("Óeydd Þingstig — á töflunni")).toBe("50");
-      expect(stat("Varanleg uppörvun")).toBe("+25%");
+      expect(stat("Varanleg uppörvun")).toBe(
+        `+${Math.round(prestigeBonusPct(50)).toLocaleString("is-IS")}%`
+      );
     });
 
     it("switching back to a chair you already own is free", () => {

--- a/frontend/components/leikir/arnor-clicker/__tests__/gameData.test.ts
+++ b/frontend/components/leikir/arnor-clicker/__tests__/gameData.test.ts
@@ -16,6 +16,8 @@ import {
   clickShare,
   clickPower,
   prestigeMult,
+  prestigeBonusPct,
+  prestigeBonusGainPct,
   baseRateOf,
   upgradeUnlocked,
   upgradeEffect,
@@ -169,14 +171,56 @@ describe("clickMult / workMult", () => {
 });
 
 // ── prestigeMult ──────────────────────────────────────────────────────────────
+// The boost was linear (+0.5% a point) and fed back into itself: a bigger
+// multiplier produced more lifetime, lifetime became Þingstig, Þingstig bought a
+// bigger multiplier. A player reached 16,176,203 Þingstig and +8,088,102%. The
+// square root breaks that loop, and these pin the shape rather than the values,
+// so a future retune cannot quietly restore the runaway.
 describe("prestigeMult", () => {
   it("no Þingstig → ×1", () => {
     expect(prestigeMult(0)).toBe(1);
   });
 
-  it("each point adds 0.5%", () => {
-    expect(prestigeMult(100)).toBeCloseTo(1.5, 10);
-    expect(prestigeMult(200)).toBeCloseTo(2, 10);
+  it("a first prestige is still worth +5%, as it always was", () => {
+    // thingstigFor(PRESTIGE_UNLOCK) is 10 — the point the curve is anchored to.
+    expect(prestigeBonusPct(10)).toBeCloseTo(5, 10);
+  });
+
+  it("grows with the square root: doubling Þingstig gives ~1.41×, not 2×", () => {
+    const ratio = prestigeBonusPct(2000) / prestigeBonusPct(1000);
+    expect(ratio).toBeCloseTo(Math.SQRT2, 10);
+    // A hundredfold in Þingstig is only tenfold in boost.
+    expect(prestigeBonusPct(100_000) / prestigeBonusPct(1000)).toBeCloseTo(10, 10);
+  });
+
+  it("keeps the reported runaway balance to a sane multiplier", () => {
+    // The real figure from the leaderboard. Linear gave ×80,882.
+    expect(prestigeMult(16_176_203)).toBeLessThan(100);
+    expect(prestigeMult(16_176_203)).toBeGreaterThan(10);
+  });
+
+  it("is monotonic and never negative, even on a corrupt balance", () => {
+    expect(prestigeMult(-5)).toBe(1);
+    let prev = 0;
+    for (const t of [0, 10, 100, 1e4, 1e6, 1e9]) {
+      const m = prestigeMult(t);
+      expect(m).toBeGreaterThanOrEqual(prev);
+      prev = m;
+    }
+  });
+});
+
+describe("prestigeBonusGainPct", () => {
+  it("is the difference between two points on the curve, not a function of the gain", () => {
+    // On a square root the same gain is worth less the more you already hold —
+    // so the prestige button must show a delta.
+    const early = prestigeBonusGainPct(0, 100);
+    const late = prestigeBonusGainPct(1_000_000, 100);
+    expect(early).toBeGreaterThan(late);
+    expect(prestigeBonusGainPct(500, 250)).toBeCloseTo(
+      prestigeBonusPct(750) - prestigeBonusPct(500),
+      10
+    );
   });
 });
 
@@ -201,8 +245,9 @@ describe("baseRateOf", () => {
 
   it("applies work upgrades and prestige multiplier on top", () => {
     const counts = WORKERS.map((_, i) => (i === 0 ? 1 : 0));
-    // kaffi = ×1.5 work, tsCur 200 = ×2 prestige → 0.1 * 1.5 * 2 = 0.3
-    expect(baseRateOf(counts, new Set(["kaffi"]), 200)).toBeCloseTo(0.3, 10);
+    // kaffi = ×1.5 work, plus whatever the prestige curve gives at 200 Þingstig.
+    const expected = thingfulltrui.out * 1.5 * prestigeMult(200);
+    expect(baseRateOf(counts, new Set(["kaffi"]), 200)).toBeCloseTo(expected, 10);
   });
 
   it("applies a per-worker upgrade to that worker alone", () => {
@@ -251,8 +296,9 @@ describe("clickPower", () => {
   });
 
   it("multiplies click upgrades, prestige and the combo together", () => {
-    // ristabraud ×2, tsCur 200 → ×2 prestige, combo 10 at step 0.1 → ×2
-    expect(clickPower(new Set(["ristabraud"]), 200, 0, NO_BUFF, 10, 0.1)).toBeCloseTo(8, 10);
+    // ristabraud ×2, combo 10 at step 0.1 → ×2, times the prestige curve.
+    const expected = 2 * 2 * prestigeMult(200);
+    expect(clickPower(new Set(["ristabraud"]), 200, 0, NO_BUFF, 10, 0.1)).toBeCloseTo(expected, 10);
   });
 
   it("adds the share of the passive rate on top of the tap", () => {

--- a/frontend/components/leikir/arnor-clicker/gameData.ts
+++ b/frontend/components/leikir/arnor-clicker/gameData.ts
@@ -245,8 +245,9 @@ export function costOf(w: Worker, owned: number, qty: number): number {
 // ── Fundarstjórar ────────────────────────────────────────────────────────────
 // The player picks who chairs the þing. Each chair brings one ability, bought
 // once with Þingstig and kept forever (switching between owned chairs is free).
-// Paying in Þingstig is a real trade: every point spent is 0.5% permanent boost
-// given up. Chair-specific upgrades live in UPGRADES behind `req.chair`.
+// Paying in Þingstig is a real trade: spending them lowers the permanent boost
+// they buy, and the boost follows a square-root curve (see prestigeMult).
+// Chair-specific upgrades live in UPGRADES behind `req.chair`.
 
 export type ChairAbility = "golden" | "combo";
 
@@ -1003,8 +1004,30 @@ export function thingstigFor(lifetime: number): number {
   if (lifetime < PRESTIGE_UNLOCK) return 0;
   return Math.floor(K * Math.sqrt(lifetime / SCALE));
 }
-/** Each Þingstig gives +0.5% to everything (compounds across prestiges). */
-export const PRESTIGE_MULT_PER_POINT = 0.005;
+/**
+ * The permanent boost Þingstig buy, as a multiplier on everything.
+ *
+ * This grows with the *square root* of Þingstig held, and that shape is the
+ * whole point. It used to be linear — +0.5% a point — which fed back into
+ * itself: a bigger multiplier produced more lifetime fundarstig, `thingstigFor`
+ * turns lifetime into Þingstig, and those bought a bigger multiplier again. One
+ * player reached 16,176,203 Þingstig and a boost of +8,088,102%, at which point
+ * the numbers stop meaning anything and the leaderboard is decided by who
+ * started compounding first.
+ *
+ * Under a square root, doubling Þingstig multiplies the boost by ~1.41 rather
+ * than 2, so the loop converges instead of exploding. The curve is anchored so
+ * a first prestige is worth the same +5% it always was — the early game is
+ * untouched, and only the far tail is pulled in. That same player now sits at
+ * about ×65 rather than ×80,882.
+ *
+ * Þingstig balances are not rescaled: nobody loses points, the points simply
+ * buy a saner amount of power.
+ */
+/** Þingstig from a first prestige — the point the curve is anchored to. */
+const FIRST_PRESTIGE_THINGSTIG = 10;
+/** Boost at that first prestige. Growth beyond it follows √Þingstig. */
+export const PRESTIGE_BONUS_AT_FIRST = 0.05;
 
 /**
  * Highest Þingstig the leaderboard will store.
@@ -1204,8 +1227,19 @@ export const workerMult = (workerKey: string, ups: Set<string>) =>
 /** Fraction of the current rate each click also earns, from owned upgrades. */
 export const clickShare = (ups: Set<string>) =>
   UPGRADES.reduce((s, u) => (u.share && ups.has(u.key) ? s + u.share : s), 0);
-/** Permanent prestige multiplier from current Þingstig. */
-export const prestigeMult = (tsCur: number) => 1 + PRESTIGE_MULT_PER_POINT * tsCur;
+/** Permanent prestige multiplier from current Þingstig. See the constants above. */
+export const prestigeMult = (tsCur: number) =>
+  1 + PRESTIGE_BONUS_AT_FIRST * Math.sqrt(Math.max(tsCur, 0) / FIRST_PRESTIGE_THINGSTIG);
+/** The permanent boost as a percentage, for display: ×1.05 reads as 5. */
+export const prestigeBonusPct = (tsCur: number) => (prestigeMult(tsCur) - 1) * 100;
+
+/**
+ * Percentage points a prestige would *add*, which on a square-root curve is the
+ * difference between the two points — not a function of the gain on its own.
+ */
+export const prestigeBonusGainPct = (tsCur: number, gain: number) =>
+  prestigeBonusPct(tsCur + gain) - prestigeBonusPct(tsCur);
+
 /** Passive fundarstig/sec from owned workers, with upgrade + prestige multipliers. */
 export const baseRateOf = (counts: number[], ups: Set<string>, tsCur: number) =>
   WORKERS.reduce((s, w, i) => s + w.out * (counts[i] ?? 0) * workerMult(w.key, ups), 0) *


### PR DESCRIPTION
Reported by Kría: *"Það þarf klárlega að nerfa varanlegu uppörvunina amk ég er með +8 088 102% núna frá því að ég frestaði þingi síðast."*

## It wasn't cheating — it was the design

+8,088,102% is exactly `1 + 0.005 × 16,176,203`, her Þingstig balance, to the digit.

The boost was **linear in Þingstig, and fed back into itself**: a bigger multiplier produces more lifetime fundarstig → `thingstigFor` turns lifetime into Þingstig → those buy a bigger multiplier again. Nothing in that loop pushes back, so it compounds until the numbers stop meaning anything and the table is decided by who started compounding first.

## The fix

The boost now grows with the **square root** of Þingstig held. Doubling Þingstig multiplies it by ~1.41 rather than 2, so the loop converges instead of exploding — it's a change of exponent, not just of constant.

The curve is anchored so a **first prestige is worth the same +5% it always was**. The early game is untouched; only the far tail is pulled in:

| Þingstig | before | after |
|---:|---:|---:|
| 10 *(first prestige)* | +5% | **+5%** |
| 1,000 | ×6 | ×1.5 |
| 1,000,000 | ×5,001 | ×16.8 |
| 16,176,203 *(Kría)* | ×80,882 | **×64.6** |

**Þingstig balances are not rescaled.** Nobody loses points; the points simply buy a saner amount of power, and Kría stays comfortably top of the table.

One consequence worth noting: because the curve is no longer linear, the prestige button's "+N% varanlega" has to show the **difference between two points** on it, not a function of the gain alone — the same gain is worth less the more you already hold. Both display sites now go through helpers that live beside the curve.

## Tests pin the shape, not the numbers

That a first prestige is +5%, that doubling gives ~√2, that a hundredfold in Þingstig is only tenfold in boost, and that the real reported balance lands under ×100. A future retune can move the constant but can't quietly restore the runaway without failing those. 292 frontend tests, build clean.

## Please tell Kría before this lands

Her on-screen boost drops from +8,088,102% to about +6,359%. That's a 1,244× cut and it will feel dramatic even though she keeps every Þingstig and her place at the top. Better she hears it from you than discovers it.

## Related, not fixed here

She also said *"Ég sé ekki hvaða tala þetta er — breytist svo hratt að mér líður eins og ég sé að horfa á millisekúnduklukku."* The readout refreshes 8×/sec at 3 significant figures. I've deliberately **not** touched it in this PR: her production drops by three orders of magnitude here, which may resolve the churn on its own. Worth re-checking with her after this lands rather than changing both at once and not knowing which did what.

🤖 Generated with [Claude Code](https://claude.com/claude-code)